### PR TITLE
Added GlobalConfiguration to Timestamper Plugin

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/TimestampNote.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestampNote.java
@@ -53,7 +53,6 @@ public final class TimestampNote extends ConsoleNote<Object> {
      */
     @Override
     protected SimpleDateFormat initialValue() {
-      // return new SimpleDateFormat(Messages.TimestampFormat());
       return new SimpleDateFormat(TimestamperConfig.get().getTimestampFormat());
     }
   };
@@ -83,9 +82,7 @@ public final class TimestampNote extends ConsoleNote<Object> {
         new Date(millisSinceEpoch));
     // Add as end tag, which will be inserted prior to tags added by other
     // console notes (e.g. AntTargetNote).
-    // String linePrefix = Messages.LinePrefix(formattedDate);
-    String linePrefix = MessageFormat.format(TimestamperConfig.get().getLinePrefix(), formattedDate);
-    text.addMarkup(0, 0, "", linePrefix);
+    text.addMarkup(0, 0, "", formattedDate);
     return null;
   }
 }

--- a/src/main/java/hudson/plugins/timestamper/TimestamperConfig.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestamperConfig.java
@@ -22,28 +22,15 @@ public class TimestamperConfig extends GlobalConfiguration {
     private String timestampFormat;
 
     /**
-     * line prefix containing one {0} that gets the formatted timestamp.
-     */
-    private String linePrefix;
-
-    /**
      * default for timestamp format
      */
-    public static final String DEFAULT_TIMESTAMP_FORMAT="HH:mm:ss";
-
-    /**
-     * default for line prefix
-     */
-    public static final String DEFAULT_LINE_PREFIX="<b>{0}</b>  ";
+    public static final String DEFAULT_TIMESTAMP_FORMAT="'<b>'HH:mm:ss'</b> '";
 
     /**
      * Constructor
      */
     public TimestamperConfig() {
-        // unit test has no Jenkins in this case
-        if(Jenkins.getInstance() != null) {
-            load();
-        }
+        load();
     }
 
     /**
@@ -64,22 +51,6 @@ public class TimestamperConfig extends GlobalConfiguration {
     }
 
     /**
-     * Returns the line prefix containing {0} to render the formatted timestamp.
-     * @return the line prefix
-     */
-    public String getLinePrefix() {
-        return StringUtils.isEmpty(linePrefix) ? DEFAULT_LINE_PREFIX : this.linePrefix;
-    }
-
-    /**
-     * Sets the line prefix. One {0} must be used to render the formatted timestamp.
-     * @param linePrefix the line prefix containing {0}
-     */
-    public void setLinePrefix(String linePrefix) {
-        this.linePrefix = StringUtils.isEmpty(linePrefix) ? DEFAULT_LINE_PREFIX : linePrefix;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -94,15 +65,6 @@ public class TimestamperConfig extends GlobalConfiguration {
      * @return the Timestamper config instance.
      */
     public static TimestamperConfig get() {
-        if(Jenkins.getInstance() != null && GlobalConfiguration.all() != null) {
-            return GlobalConfiguration.all().get(TimestamperConfig.class);
-        }
-
-        // MOCK for testing...
-        TimestamperConfig config = new TimestamperConfig();
-        config.setLinePrefix(DEFAULT_LINE_PREFIX);
-        config.setTimestampFormat(DEFAULT_TIMESTAMP_FORMAT);
-
-        return config;
+        return GlobalConfiguration.all().get(TimestamperConfig.class);
     }
 }

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/config.groovy
@@ -6,8 +6,4 @@ f.section(title:_("Timestamper Format")) {
     f.entry(title: _("Timestamp format"), field:"timestampFormat") {
         f.textbox()
     }
-
-    f.entry(title: _("Line Prefix"), field:"linePrefix") {
-        f.textbox()
-    }
 }

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-linePrefix.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-linePrefix.html
@@ -1,5 +1,0 @@
-<div>
-    The line prefix defines how the formatted timestamp is rendered in front of the line. Default is "&lt;b&gt;{0}&lt;/b&gt; ".
-    <br />
-    Example to use the pipe symbol as separator: "{0} | "
-</div>

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-timestampFormat.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-timestampFormat.html
@@ -2,5 +2,5 @@
     The timestamp format defines, how the time will be rendered.
     The <a href="http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html">http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html</a> pattern are used.
     <br />
-    Default is "HH:mm:ss". For a more detailed format use "yyyy-MM-dd HH:mm:ss.SSS".
+    Default is "'<b>'HH:mm:ss'</b> '". For a more detailed format use "yyyy-MM-dd HH:mm:ss.SSS' | '".
 </div>

--- a/src/test/java/hudson/plugins/timestamper/TimestampNoteTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestampNoteTest.java
@@ -29,72 +29,72 @@ import hudson.MarkupText;
 import hudson.console.ConsoleNote;
 import hudson.tasks._ant.AntTargetNote;
 
-import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
 import org.apache.commons.lang.SerializationUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import org.jvnet.hudson.test.HudsonTestCase;
 
 /**
  * Unit test for the {@link TimestampNote} class.
  */
-public class TimestampNoteTest {
+public class TimestampNoteTest extends HudsonTestCase {
 
   private static TimeZone systemDefaultTimeZone;
-  private static String expectedLinePrefix;
+  private static String expectedFormattedTimestamp;
 
   /**
    */
-  @BeforeClass
-  public static void beforeClass() {
+  @Override
+  protected void setUp() throws Exception {
     systemDefaultTimeZone = TimeZone.getDefault();
     // Set the time zone to get consistent results.
     TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
     SimpleDateFormat smf = new SimpleDateFormat(TimestamperConfig.DEFAULT_TIMESTAMP_FORMAT);
-    expectedLinePrefix = MessageFormat.format(TimestamperConfig.DEFAULT_LINE_PREFIX, smf.format(new Date(0)));
+    expectedFormattedTimestamp = smf.format(new Date(0));
+    super.setUp();
   }
 
   /**
    */
-  @AfterClass
-  public static void afterClass() {
+  @Override
+  protected void tearDown() throws Exception  {
     TimeZone.setDefault(systemDefaultTimeZone);
+    super.tearDown();
   }
 
   /**
    */
   @Test
-  public void timestampNote() {
+  public void testTimestampNote() {
     assertThat(annotate("line", new TimestampNote(0)),
-        is(expectedLinePrefix + "line"));
+        is(expectedFormattedTimestamp + "line"));
   }
 
   /**
    */
   @Test
-  public void serialization() {
+  public void testSerialization() {
     assertThat(annotate("line", serialize(new TimestampNote(0))),
-        is(expectedLinePrefix + "line"));
+        is(expectedFormattedTimestamp + "line"));
   }
 
   /**
    */
   @Test
-  public void timestampThenAntTargetNote() {
+  public void testTimestampThenAntTargetNote() {
     assertThat(annotate("target:", new TimestampNote(0), new AntTargetNote()),
-        is(expectedLinePrefix + "<b class=ant-target>target</b>:"));
+        is(expectedFormattedTimestamp + "<b class=ant-target>target</b>:"));
   }
 
   /**
    */
   @Test
-  public void antTargetNoteThenTimestamp() {
+  public void testAntTargetNoteThenTimestamp() {
     assertThat(annotate("target:", new AntTargetNote(), new TimestampNote(0)),
-        is(expectedLinePrefix + "<b class=ant-target>target</b>:"));
+        is(expectedFormattedTimestamp + "<b class=ant-target>target</b>:"));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
I added a GlobalConfiguration to the Timestamper Plugin to set the timestamp format and the line prefix pattern in the Jenkins Configure System page. Please have a look at my changes. 

Regards, Frederik
