### PR TITLE
JENKINS-16778: Timestamper makes the build fail if the slave is put offline during the build.

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory.java
@@ -62,6 +62,10 @@ public final class TimestampAnnotatorFactory extends
    * @return the offset in bytes
    */
   private static long getOffset(StaplerRequest request) {
+    // Rare case where a Jenkins slave is put offline, while build job is still running
+    if (null == request) {
+        return 0;
+    }
     String path = request.getPathInfo();
     if (path == null) {
       // JENKINS-16438


### PR DESCRIPTION
Fixes issue JENKINS-16778

I've tested this on a local Jenkins instance, with one slave.
