### PR TITLE
fix broken help links

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat.html
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <div>
     The elapsed time format defines how the timestamps will be rendered when the elapsed time option has been selected.
-    The <a href="http://commons.apache.org/lang/api-2.4/org/apache/commons/lang/time/DurationFormatUtils.html">Commons Lang DurationFormatUtils</a> pattern is used.
+    The <a href="http://commons.apache.org/proper/commons-lang/javadocs/api-3.1/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang DurationFormatUtils</a> pattern is used.
     <p>
     Default is: <code>'&lt;b&gt;'HH:mm:ss.S'&lt;/b&gt; '</code>
 </div>

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat_zh_TW.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat_zh_TW.html
@@ -1,6 +1,6 @@
 <div>
     經過時間格式定義了選用「經過時間」選項該怎麼顯示時間戳記。
-    使用 <a href="http://commons.apache.org/lang/api-2.4/org/apache/commons/lang/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> 模式。
+    使用 <a href="http://commons.apache.org/proper/commons-lang/javadocs/api-3.1/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> 模式。
     <p>
     預設值是: <code>'&lt;b&gt;'HH:mm:ss.S'&lt;/b&gt; '</code>
 </div>


### PR DESCRIPTION
The links to the old 2.4 Apache commons documentation are no longer working. Replacing them by links to 3.1.
