### PR TITLE
JENKINS-23867 - updating javascript to work with new core div layout in 1.572

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory/script.js
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory/script.js
@@ -85,8 +85,16 @@ function timestampFound() {
         return;
     }
     settingsInserted = true;
+
+    // for div layout in >= 1.572 we need to use 'side-panel-content'
+    var element = document.getElementById('side-panel-content');
+    if (null == element) {
+        // for < 1.572 we need to use 'navigation'
+        element = document.getElementById('navigation');
+    }
+
     new Ajax.Updater(
-        document.getElementById('navigation'),
+        element,
         rootURL + "/extensionList/hudson.console.ConsoleAnnotatorFactory/hudson.plugins.timestamper.annotator.TimestampAnnotatorFactory/usersettings",
         { insertion: Insertion.After, onComplete: init }
     );


### PR DESCRIPTION
Hi,

for jenkins core >= 1.572 we need to use document.getElementById('side-panel-content')
for compatibility with < 1.572 we need to fall back to using document.getElementById('navigation')

all feedback welcome, 
thanks
Geoff
