### PR TITLE
[JENKINS-30351] Configuration option to write plain timestamp entries on build log file

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/PlainTimestampNotesOutputStream.java
+++ b/src/main/java/hudson/plugins/timestamper/PlainTimestampNotesOutputStream.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2015 Steven G. Brown
+ * Copyright (c) 2015 Cloudbees Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,33 +23,17 @@
  */
 package hudson.plugins.timestamper;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import hudson.console.LineTransformationOutputStream;
-
 import java.io.IOException;
 import java.io.OutputStream;
 
 /**
  * Output stream that writes each line to the provided delegate output stream
- * after inserting a {@link TimestampNote}.
- * 
- * @author Steven G. Brown
+ * after inserting a {@link TimestampNote} as plain text.
  */
-class TimestampNotesOutputStream extends LineTransformationOutputStream {
+class PlainTimestampNotesOutputStream extends TimestampNotesOutputStream {
 
-  /**
-   * The delegate output stream.
-   */
-  protected final OutputStream delegate;
-
-  /**
-   * Create a new {@link TimestampNotesOutputStream}.
-   * 
-   * @param delegate
-   *          the delegate output stream
-   */
-  TimestampNotesOutputStream(OutputStream delegate) {
-    this.delegate = checkNotNull(delegate);
+  PlainTimestampNotesOutputStream(OutputStream delegate) {
+    super(delegate);
   }
 
   /**
@@ -57,16 +41,8 @@ class TimestampNotesOutputStream extends LineTransformationOutputStream {
    */
   @Override
   protected void eol(byte[] b, int len) throws IOException {
-    new TimestampNote(System.currentTimeMillis()).encodeTo(delegate);
+    new TimestampNote(System.currentTimeMillis()).plain(delegate);
     delegate.write(b, 0, len);
   }
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void close() throws IOException {
-    super.close();
-    delegate.close();
-  }
 }

--- a/src/main/java/hudson/plugins/timestamper/PlainTimestampNotesOutputStream.java
+++ b/src/main/java/hudson/plugins/timestamper/PlainTimestampNotesOutputStream.java
@@ -26,13 +26,15 @@ package hudson.plugins.timestamper;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * Output stream that writes each line to the provided delegate output stream
  * after inserting a {@link TimestampNote} as plain text.
  */
 class PlainTimestampNotesOutputStream extends TimestampNotesOutputStream {
 
-  PlainTimestampNotesOutputStream(OutputStream delegate) {
+  PlainTimestampNotesOutputStream(@NonNull OutputStream delegate) {
     super(delegate);
   }
 

--- a/src/main/java/hudson/plugins/timestamper/TimestampNote.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestampNote.java
@@ -23,12 +23,17 @@
  */
 package hudson.plugins.timestamper;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.SimpleDateFormat;
+
 import hudson.MarkupText;
 import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleNote;
 import hudson.model.Run;
 import hudson.plugins.timestamper.action.TimestampsAction;
 import hudson.plugins.timestamper.format.TimestampFormatter;
+import jenkins.model.GlobalConfiguration;
 
 /**
  * Time-stamp note that was inserted into the console note by the Timestamper
@@ -61,6 +66,10 @@ public final class TimestampNote extends ConsoleNote<Object> {
    */
   public static String getSystemProperty() {
     return "timestamper-consolenotes";
+  }
+
+  public static String getUsePlainSystemProperty() {
+    return "timestamper-consolenotes-plain";
   }
 
   /**
@@ -103,5 +112,12 @@ public final class TimestampNote extends ConsoleNote<Object> {
       formatter.markup(text, timestamp);
     }
     return null; // each time-stamp note affects one line only
+  }
+
+  public void plain(OutputStream out) throws IOException {
+    TimestamperConfig config = GlobalConfiguration.all().get(TimestamperConfig.class);
+    String format = config.getSystemTimeFormat();
+    SimpleDateFormat df = new SimpleDateFormat(format);
+    out.write(df.format(millisSinceEpoch).getBytes());
   }
 }

--- a/src/main/java/hudson/plugins/timestamper/TimestamperBuildWrapper.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestamperBuildWrapper.java
@@ -92,18 +92,24 @@ public final class TimestamperBuildWrapper extends SimpleBuildWrapper {
     private final File timestampsFile;
     private final long buildStartTime;
     private final boolean useTimestampNotes;
+    private final boolean usePlainTimestampNotes;
 
     ConsoleLogFilterImpl(Run<?,?> build) {
       this.timestampsFile = TimestamperPaths.timestampsFile(build);
       this.buildStartTime = build.getTimeInMillis();
-      useTimestampNotes = !(build instanceof AbstractBuild) || Boolean.getBoolean(TimestampNote.getSystemProperty());
+      usePlainTimestampNotes = Boolean.getBoolean(TimestampNote.getUsePlainSystemProperty());
+      useTimestampNotes = !(build instanceof AbstractBuild) || Boolean.getBoolean(TimestampNote.getSystemProperty()) || usePlainTimestampNotes;
     }
 
     @SuppressWarnings("rawtypes")
     @Override
     public OutputStream decorateLogger(AbstractBuild _ignore, OutputStream logger) throws IOException, InterruptedException {
       if (useTimestampNotes) {
-        return new TimestampNotesOutputStream(logger);
+        if (usePlainTimestampNotes) {
+          return new PlainTimestampNotesOutputStream(logger);
+        } else {
+          return new TimestampNotesOutputStream(logger);
+        }
       }
       Optional<MessageDigest> digest = Optional.absent();
       try {


### PR DESCRIPTION
[JENKINS-30351](https://issues.jenkins-ci.org/browse/JENKINS-30351)