### PR TITLE
Performance improvement: don't scan entire log file on every chunk

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParser.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParser.java
@@ -41,7 +41,9 @@ interface ConsoleLogParser extends Serializable {
    * Skip to a position in the console log file.
    * 
    * @param text
-   *          the build to inspect
+   *          the text to parse
+   * @param length
+   *          the length of log file
    * @return the result
    * @throws IOException
    */

--- a/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParser.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParser.java
@@ -40,12 +40,12 @@ interface ConsoleLogParser extends Serializable {
   /**
    * Skip to a position in the console log file.
    * 
-   * @param build
+   * @param text
    *          the build to inspect
    * @return the result
    * @throws IOException
    */
-  Result seek(Run<?, ?> build) throws IOException;
+  Result seek(String text, long length) throws IOException;
 
   static final class Result {
 

--- a/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParserImpl.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParserImpl.java
@@ -23,10 +23,8 @@
  */
 package hudson.plugins.timestamper.annotator;
 
-import hudson.model.Run;
 import hudson.plugins.timestamper.io.Closeables;
-
-import java.io.BufferedInputStream;
+import org.apache.tools.ant.filters.StringInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -60,14 +58,14 @@ class ConsoleLogParserImpl implements ConsoleLogParser {
    * {@inheritDoc}
    */
   @Override
-  public ConsoleLogParser.Result seek(Run<?, ?> build) throws IOException {
+  public ConsoleLogParser.Result seek(String text, long length) throws IOException {
     ConsoleLogParser.Result result = new ConsoleLogParser.Result();
     result.atNewLine = true;
-    InputStream inputStream = new BufferedInputStream(build.getLogInputStream());
+    InputStream inputStream = new StringInputStream(text);
     try {
       long posFromStart = pos;
       if (pos < 0) {
-        posFromStart = build.getLogText().length() + pos;
+        posFromStart = length + pos;
       }
       for (long i = 0; i < posFromStart; i++) {
         int value = inputStream.read();

--- a/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
@@ -82,7 +82,7 @@ public final class TimestampAnnotator extends ConsoleAnnotator<Object> {
 
     try {
       if (timestampsReader == null) {
-        ConsoleLogParserImpl.Result logPosition = logParser.seek(build);
+        ConsoleLogParserImpl.Result logPosition = logParser.seek(text.getText(), build.getLogFile().length());
         if (logPosition.endOfFile) {
           return null; // do not annotate the following lines
         }

--- a/src/main/java/hudson/plugins/timestamper/format/TimestampFormatProvider.java
+++ b/src/main/java/hudson/plugins/timestamper/format/TimestampFormatProvider.java
@@ -98,7 +98,7 @@ public class TimestampFormatProvider {
     } else {
       // "system", no mode cookie, or unrecognised mode cookie
       Optional<String> timeZoneId = Optional.absent();
-      if (local != null && local.booleanValue()) {
+      if (Boolean.TRUE.equals(local)) {
         try {
           String localTimeZoneId = convertOffsetToTimeZoneId(offset);
           timeZoneId = Optional.of(localTimeZoneId);

--- a/src/test/java/hudson/plugins/timestamper/annotator/ConsoleLogParserImplTest.java
+++ b/src/test/java/hudson/plugins/timestamper/annotator/ConsoleLogParserImplTest.java
@@ -25,12 +25,6 @@ package hudson.plugins.timestamper.annotator;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import hudson.console.AnnotatedLargeText;
-import hudson.model.Run;
-
-import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -72,7 +66,7 @@ public class ConsoleLogParserImplTest {
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
 
-  private Run<?, ?> build;
+  private String consoleLog;
 
   private int logLength;
 
@@ -81,16 +75,9 @@ public class ConsoleLogParserImplTest {
    */
   @Before
   public void setUp() throws Exception {
-    build = mock(Run.class);
-    when(build.getRootDir()).thenReturn(folder.getRoot());
-    byte[] consoleLog = new byte[] { 0x61, NEWLINE, NEWLINE, NEWLINE, NEWLINE,
-        0x61, NEWLINE };
-    logLength = consoleLog.length;
-    when(build.getLogInputStream()).thenReturn(
-        new ByteArrayInputStream(consoleLog));
-    AnnotatedLargeText<?> logText = mock(AnnotatedLargeText.class);
-    when(logText.length()).thenReturn((long) logLength);
-    when(build.getLogText()).thenReturn(logText);
+    consoleLog = new String(new byte[] { 0x61, NEWLINE, NEWLINE, NEWLINE, NEWLINE,
+            0x61, NEWLINE });
+    logLength = consoleLog.length();
   }
 
   /**
@@ -185,6 +172,6 @@ public class ConsoleLogParserImplTest {
     if (serialize) {
       parser = (ConsoleLogParserImpl) SerializationUtils.clone(parser);
     }
-    return parser.seek(build);
+    return parser.seek(consoleLog, logLength);
   }
 }

--- a/src/test/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorTest.java
@@ -37,6 +37,7 @@ import hudson.plugins.timestamper.format.TimestampFormat;
 import hudson.plugins.timestamper.format.TimestampFormatProvider;
 import hudson.plugins.timestamper.io.TimestampsWriter;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -102,6 +103,7 @@ public class TimestampAnnotatorTest {
   public void setUp() throws Exception {
     build = mock(Run.class);
     when(build.getRootDir()).thenReturn(folder.getRoot());
+    when(build.getLogFile()).thenReturn(mock(File.class));
 
     logPosition = new ConsoleLogParserImpl.Result();
     capturedTimestamps = new ArrayList<Timestamp>();
@@ -178,7 +180,9 @@ public class TimestampAnnotatorTest {
       if (serialize) {
         annotator = (ConsoleAnnotator) SerializationUtils.clone(annotator);
       }
-      annotator = annotator.annotate(build, mock(MarkupText.class));
+      MarkupText text = mock(MarkupText.class);
+      when(text.getText()).thenReturn("Something");
+      annotator = annotator.annotate(build, text);
       iterations++;
       if (iterations > 100) {
         throw new AssertionError("annotator is not terminating");
@@ -212,7 +216,7 @@ public class TimestampAnnotatorTest {
     private static final long serialVersionUID = 1L;
 
     @Override
-    public Result seek(Run<?, ?> build) throws IOException {
+    public Result seek(String ignored1, long ignored2) throws IOException {
       return logPosition;
     }
   }


### PR DESCRIPTION
Hi,

I hope that I found a cheap way to make timestamper plugin a much faster (and decrease memory footprint). I tested this change in our Jenkins and it seems that everything are working as before, but faster.

@StevenGBrown, could you take a look into my PR?