### PR TITLE
Read tail for finished build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
   <properties>
     <jenkins.version>1.608</jenkins.version> <!-- SimpleBuildWrapper.createLoggerDecorator -->
-    <java.level>6</java.level>
+    <java.level>7</java.level>
     <hamcrest.version>1.3</hamcrest.version>
   </properties>
 

--- a/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParserImpl.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParserImpl.java
@@ -24,7 +24,6 @@
 package hudson.plugins.timestamper.annotator;
 
 import hudson.model.Run;
-import hudson.plugins.timestamper.io.Closeables;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -34,7 +33,7 @@ import javax.annotation.concurrent.Immutable;
 
 /**
  * Implementation of ConsoleLogParser.
- * 
+ *
  * @author Steven G. Brown
  */
 @Immutable
@@ -46,7 +45,7 @@ class ConsoleLogParserImpl implements ConsoleLogParser {
 
   /**
    * Create a new {@link ConsoleLogParserImpl}.
-   * 
+   *
    * @param pos
    *          the position to find in the console log file. A non-negative
    *          position is from the start of the file, and a negative position is
@@ -63,8 +62,7 @@ class ConsoleLogParserImpl implements ConsoleLogParser {
   public ConsoleLogParser.Result seek(Run<?, ?> build) throws IOException {
     ConsoleLogParser.Result result = new ConsoleLogParser.Result();
     result.atNewLine = true;
-    InputStream inputStream = new BufferedInputStream(build.getLogInputStream());
-    try {
+    try (InputStream inputStream = new BufferedInputStream(build.getLogInputStream())) {
       long posFromStart = pos;
       if (pos < 0) {
         posFromStart = build.getLogText().length() + pos;
@@ -80,8 +78,6 @@ class ConsoleLogParserImpl implements ConsoleLogParser {
           result.lineNumber++;
         }
       }
-    } finally {
-      Closeables.closeQuietly(inputStream);
     }
     return result;
   }

--- a/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
@@ -49,8 +49,7 @@ public final class TimestampAnnotator extends ConsoleAnnotator<Object> {
 
   private static final long serialVersionUID = 1L;
 
-  private static final Logger LOGGER = Logger
-      .getLogger(TimestampAnnotator.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(TimestampAnnotator.class.getName());
 
   private final ConsoleLogParser logParser;
 
@@ -86,6 +85,13 @@ public final class TimestampAnnotator extends ConsoleAnnotator<Object> {
         if (logPosition.endOfFile) {
           return null; // do not annotate the following lines
         }
+
+        if (logPosition.lineNumber < 0) {
+          TimestampsReader temproryTimestampsReader = new TimestampsReader(build);
+          logPosition.lineNumber = temproryTimestampsReader.getAbs(logPosition.lineNumber);
+          temproryTimestampsReader.close();
+        }
+
         timestampsReader = new TimestampsReader(build);
         timestampsReader.skip(logPosition.lineNumber);
         Optional<Timestamp> timestamp = timestampsReader.read();

--- a/src/test/java/hudson/plugins/timestamper/annotator/ConsoleLogParserImplTest.java
+++ b/src/test/java/hudson/plugins/timestamper/annotator/ConsoleLogParserImplTest.java
@@ -83,6 +83,7 @@ public class ConsoleLogParserImplTest {
   public void setUp() throws Exception {
     build = mock(Run.class);
     when(build.getRootDir()).thenReturn(folder.getRoot());
+    when(build.isBuilding()).thenReturn(true);
     byte[] consoleLog = new byte[] { 0x61, NEWLINE, NEWLINE, NEWLINE, NEWLINE,
         0x61, NEWLINE };
     logLength = consoleLog.length;


### PR DESCRIPTION
@StevenGBrown, Hi! I hope this PR would be much better.
It's the most conservative way to implement [idea](https://github.com/jenkinsci/timestamper-plugin/pull/17#issuecomment-234603177) from https://github.com/jenkinsci/timestamper-plugin/pull/17.

Now plugin is parsing log file from tail then build is finished. It helps to show `/console` faster with less memory usage.
Unfortunately, I didn't find a way to read `VarInt` in reverse order, so, in this implementation plugin reads timestamp files one extra time - to find correct line.