### PR TITLE
Bypass TimestampAnnotatorFactory3 right away if we are rendering a WorkflowRun

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/TimestampNote.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestampNote.java
@@ -67,6 +67,10 @@ public final class TimestampNote extends ConsoleNote<Object> {
     return "timestamper-consolenotes";
   }
 
+  public static boolean useTimestampNotes(Run<?, ?> build) {
+      return !(build instanceof AbstractBuild) || Boolean.getBoolean(getSystemProperty());
+  }
+
   /**
    * The elapsed time in milliseconds since the start of the build.
    *

--- a/src/main/java/hudson/plugins/timestamper/TimestamperBuildWrapper.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestamperBuildWrapper.java
@@ -95,9 +95,7 @@ public final class TimestamperBuildWrapper extends SimpleBuildWrapper {
     ConsoleLogFilterImpl(Run<?, ?> build) {
       this.timestampsFile = TimestamperPaths.timestampsFile(build);
       this.buildStartTime = build.getStartTimeInMillis();
-      useTimestampNotes =
-          !(build instanceof AbstractBuild)
-              || Boolean.getBoolean(TimestampNote.getSystemProperty());
+      useTimestampNotes = TimestampNote.useTimestampNotes(build);
     }
 
     @SuppressWarnings("rawtypes")

--- a/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
@@ -70,9 +70,6 @@ public final class TimestampAnnotator extends ConsoleAnnotator<Object> {
   /** {@inheritDoc} */
   @Override
   public ConsoleAnnotator<Object> annotate(Object context, MarkupText text) {
-    if (!(context instanceof Run<?, ?>)) {
-      return null; // do not annotate the following lines
-    }
     Run<?, ?> build = (Run<?, ?>) context;
 
     try {

--- a/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3.java
@@ -29,6 +29,8 @@ import org.kohsuke.stapler.StaplerRequest;
 import hudson.Extension;
 import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleAnnotatorFactory;
+import hudson.model.Run;
+import hudson.plugins.timestamper.TimestampNote;
 import hudson.plugins.timestamper.format.TimestampFormat;
 import hudson.plugins.timestamper.format.TimestampFormatProvider;
 import jenkins.YesNoMaybe;
@@ -44,6 +46,13 @@ public final class TimestampAnnotatorFactory3 extends ConsoleAnnotatorFactory<Ob
   /** {@inheritDoc} */
   @Override
   public ConsoleAnnotator<Object> newInstance(Object context) {
+    if (!(context instanceof Run<?, ?>)) {
+      return null; // something else
+    }
+    Run<?, ?> build = (Run<?, ?>) context;
+    if (TimestampNote.useTimestampNotes(build)) {
+        return null; // not using this system
+    }
     StaplerRequest request = Stapler.getCurrentRequest();
     // JENKINS-16778: The request can be null when the slave goes off-line.
     if (request == null) {


### PR DESCRIPTION
While researching [JENKINS-48344](https://issues.jenkins-ci.org/browse/JENKINS-48344) I noticed that there is a `TimestampAnnotatorFactory3` extension which is apparently active on every build, and does a bit of work before [concluding that it can skip further annotation](https://github.com/jenkinsci/timestamper-plugin/blob/658f2dac39a39b561c67879ffb299dc82cb410f4/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java#L107), even on Pipeline builds on which it would _never_ apply. Better to disable the extension on such builds right away.