### PR TITLE
[JENKINS-48344] Lightweight timestamp annotations

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.37</version>
+    <version>3.23</version>
   </parent>
 
   <artifactId>timestamper</artifactId>
-  <version>1.8.11-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Timestamper</name>
@@ -36,7 +36,7 @@
     <connection>scm:git:git://github.com/jenkinsci/timestamper-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/timestamper-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/timestamper-plugin</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <repositories>
@@ -61,8 +61,11 @@
   </distributionManagement>
 
   <properties>
-    <jenkins.version>1.608</jenkins.version> <!-- SimpleBuildWrapper.createLoggerDecorator -->
-    <java.level>7</java.level>
+    <revision>1.8.11</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.121.1</jenkins.version>
+    <java.level>8</java.level>
+    <useBeta>true</useBeta>
   </properties>
 
   <build>
@@ -75,6 +78,7 @@
           <threshold>Low</threshold>
         </configuration>
       </plugin>
+      <!-- TODO pending https://github.com/andrena/macker-maven-plugin/pull/6 this is incompatible with Incrementals: target/target/generated-sources/localizer/hudson/plugins/timestamper/Messages.java:[20,8] duplicate class: hudson.plugins.timestamper.Messages
       <plugin>
         <groupId>de.andrena.tools.macker</groupId>
         <artifactId>macker-maven-plugin</artifactId>
@@ -91,6 +95,7 @@
           </execution>
         </executions>
       </plugin>
+      -->
     </plugins>
   </build>
 
@@ -98,8 +103,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>1.7</version>
-      <optional>true</optional>
+      <version>2.16</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <version>2.30-rc828.7aa7627c85df</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/76 -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -137,5 +146,37 @@
       <version>2.4.6</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.26-rc850.755e848ee6f8</version> <!-- TODO https://github.com/jenkinsci/workflow-job-plugin/pull/105 -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.56</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <version>2.22</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>scm-api</artifactId>
+        <version>2.2.6</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>structs</artifactId>
+        <version>1.15</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/src/main/java/hudson/plugins/timestamper/pipeline/GlobalAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/pipeline/GlobalAnnotator.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.plugins.timestamper.pipeline;
+
+import hudson.Extension;
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleAnnotatorFactory;
+import hudson.model.Run;
+import hudson.plugins.timestamper.Timestamp;
+import hudson.plugins.timestamper.format.TimestampFormat;
+import hudson.plugins.timestamper.format.TimestampFormatProvider;
+import java.text.ParsePosition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+
+/**
+ * Interprets marks added by {@link GlobalDecorator}.
+ */
+public final class GlobalAnnotator extends ConsoleAnnotator</* TODO pending https://github.com/jenkinsci/jenkins/pull/3662 */Object> {
+
+    private static final long serialVersionUID = 1;
+
+    @Override
+    public ConsoleAnnotator<Object> annotate(Object context, MarkupText text) {
+        if (!(context instanceof Run)) {
+            return null;
+        }
+        Run<?, ?> build = (Run<?, ?>) context;
+        long buildStartTime = build.getStartTimeInMillis();
+        String html = text.toString(true);
+        int start;
+        if (html.startsWith("<span class=\"pipeline-new-node\" ")) { // cf. LogStorage.startStep
+            start = html.indexOf('>') + 1;
+        } else {
+            start = 0;
+        }
+        if (html.startsWith("[", start)) {
+            int end = html.indexOf(']', start);
+            if (end != -1) {
+                long millisSinceEpoch = GlobalDecorator.UTC_MILLIS.get().parse(html, new ParsePosition(start + 1)).getTime();
+                Timestamp timestamp = new Timestamp(millisSinceEpoch - buildStartTime, millisSinceEpoch);
+                TimestampFormat format = TimestampFormatProvider.get();
+                format.markup(text, timestamp);
+                text.addMarkup(0, 26, "<span style=\"display: none\">", "</span>");
+            }
+        }
+        return this;
+    }
+
+    @Extension
+    public static final class Factory extends ConsoleAnnotatorFactory<Object> {
+
+        @Override
+        public ConsoleAnnotator<Object> newInstance(Object context) {
+            if (context instanceof Run && context instanceof FlowExecutionOwner.Executable) {
+                return new GlobalAnnotator();
+            }
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/timestamper/pipeline/GlobalDecorator.java
+++ b/src/main/java/hudson/plugins/timestamper/pipeline/GlobalDecorator.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.plugins.timestamper.pipeline;
+
+import hudson.Extension;
+import hudson.console.LineTransformationOutputStream;
+import hudson.model.Queue;
+import hudson.model.Run;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
+
+/**
+ * Applies plain-text timestamp prefixes to all Pipeline log lines.
+ */
+public final class GlobalDecorator extends TaskListenerDecorator {
+    
+    private static final Logger LOGGER = Logger.getLogger(GlobalDecorator.class.getName());
+
+    // TODO java.time is thread-safe but I got lost figuring out how to use it… https://stackoverflow.com/a/29626123/12916 + https://stackoverflow.com/a/26539985/12916
+    static Supplier<DateFormat> UTC_MILLIS = () -> {
+        DateFormat f = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"); // TODO java.time
+        f.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return f;
+    };
+
+    private static final long serialVersionUID = 1;
+
+    private GlobalDecorator() {}
+
+    @Override
+    public OutputStream decorate(final OutputStream logger) throws IOException, InterruptedException {
+        final DateFormat f = UTC_MILLIS.get();
+        return new LineTransformationOutputStream() {
+            @Override
+            protected void eol(byte[] b, int len) throws IOException {
+                logger.write('[');
+                logger.write(f.format(new Date()).getBytes(StandardCharsets.US_ASCII));
+                logger.write(']');
+                logger.write(' ');
+                logger.write(b, 0, len);
+            }
+        };
+    }
+
+    @Extension
+    public static final class Factory implements TaskListenerDecorator.Factory {
+
+        @Override
+        public TaskListenerDecorator of(FlowExecutionOwner owner) {
+            // TODO check a GlobalConfiguration to see if this should be enabled or not
+            // (and if so, make TimestamperStep just print a warning and add no notes)
+            try {
+                Queue.Executable executable = owner.getExecutable();
+                if (executable instanceof Run) { // we need at least getStartTimeInMillis
+                    return new GlobalDecorator();
+                }
+            } catch (IOException x) {
+                LOGGER.log(Level.WARNING, null, x);
+            }
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
[JENKINS-48344](https://issues.jenkins-ci.org/browse/JENKINS-48344)

Uses https://github.com/jenkinsci/workflow-job-plugin/pull/105 (and its upstreams) to implement much cheaper timestamping for Pipeline builds. Produces `log` file output like

```
…
[2018-09-28T22:49:03.570Z] ^[[8mha:////etc.etc.^[[0m[Pipeline] sh
[2018-09-28T22:49:03.895Z] [p] Running shell script
[2018-09-28T22:49:04.427Z] + sleep 1
[2018-09-28T22:49:05.249Z] + sleep 1
[2018-09-28T22:49:06.262Z] + sleep 1
[2018-09-28T22:49:07.281Z] + sleep 1
[2018-09-28T22:49:08.298Z] + sleep 1
…
```

which gets rendered like

![screenshot](https://user-images.githubusercontent.com/154109/46237018-e2d14b80-c34f-11e8-8f0d-9ce63e98e2ad.png)

No `ConsoleNote`s needed.

Probably needs to be tweaked a little to make this conditional, as per `TODO` comments.