### PR TITLE
JS: Avoid calling querySelector on text nodes

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/script.js
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/script.js
@@ -163,7 +163,9 @@ function onLoad() {
         mutations.forEach(function(mutation) {
             var addedNodes = mutation.addedNodes;
             for (var i = 0; i < addedNodes.length; i++) {
-                if (addedNodes[i].querySelector('span.timestamp')) {
+                var node = addedNodes[i];
+                // Element has querySelector, Node in general does not
+                if (node.querySelector && node.querySelector('span.timestamp')) {
                     observer.disconnect();
                     displaySettings();
                     return;


### PR DESCRIPTION
The script for adding settings assumes that any nodes added to the DOM supports querySelector method.
That is not true in general, for instance if you view the console output of a build that has *not* enabled timestamps and you run this in browser console
```
document.querySelector("h1").innerHTML+="🐹"
```
it will throw an exception.

The exception is also thrown in some real-life scenarios, e.g. when the Gradle plugin loads outline dynamically.

The PR simply checks for existence of the querySelector method for given node.