### PR TITLE
JENKINS-58102 GlobalAnnotator does not annotate lines that are part of a multi-line color sequence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
   <properties>
     <revision>1.10</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.121.2</jenkins.version>
     <java.level>8</java.level>
     <useBeta>true</useBeta>
   </properties>
@@ -152,9 +152,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ansicolor</artifactId>
+      <version>0.5.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
       <version>2.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>2.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
   <properties>
     <revision>1.10</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.121.2</jenkins.version>
+    <jenkins.version>2.150.3</jenkins.version>
     <java.level>8</java.level>
     <useBeta>true</useBeta>
   </properties>
@@ -154,7 +154,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ansicolor</artifactId>
-      <version>0.5.3</version>
+      <version>0.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/timestamper/pipeline/GlobalAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/pipeline/GlobalAnnotator.java
@@ -77,11 +77,14 @@ public final class GlobalAnnotator extends ConsoleAnnotator<Object> {
         }
         long buildStartTime = build.getStartTimeInMillis();
         String html = text.toString(true);
-        int start;
-        if (html.startsWith("<span class=\"pipeline-new-node\" ")) { // cf. LogStorage.startStep
-            start = html.indexOf('>') + 1;
-        } else {
-            start = 0;
+        int start = 0;
+        // cf. LogStorage.startStep
+        if (html.startsWith("<span class=\"pipeline-new-node\" ", start)) {
+            start = html.indexOf('>', start) + 1;
+        }
+        // cf. AnsiHtmlOutputStream.setForegroundColor
+        if (html.startsWith("<span style=\"color", start)) {
+            start = html.indexOf('>', start) + 1;
         }
         if (html.startsWith("[", start)) {
             int end = html.indexOf(']', start);

--- a/src/test/java/hudson/plugins/timestamper/TimestampNoteTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestampNoteTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 
 import org.apache.commons.lang.SerializationUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,6 +64,8 @@ public class TimestampNoteTest {
   private static final long ELAPSED = 4;
 
   private static final long TIME = 3;
+
+  private Supplier<TimestampFormat> originalSupplier;
 
   /** @return the test cases */
   @Parameters(name = "{0}, {1}")
@@ -116,6 +119,7 @@ public class TimestampNoteTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
+    originalSupplier = Whitebox.getInternalState(TimestampFormatProvider.class, Supplier.class);
     Whitebox.setInternalState(
         TimestampFormatProvider.class,
         new Supplier<TimestampFormat>() {
@@ -124,6 +128,11 @@ public class TimestampNoteTest {
             return format;
           }
         });
+  }
+
+  @After
+  public void tearDown() {
+    Whitebox.setInternalState(TimestampFormatProvider.class, Supplier.class, originalSupplier);
   }
 
   /** */

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -46,14 +46,6 @@ public class PipelineTest {
     @Test
     public void globalDecoratorAnnotator() throws Exception {
         WorkflowJob project = r.createProject(WorkflowJob.class);
-        /*
-         * TODO: ansicolor 0.6.1 and earlier don't properly support multi-line color output, so the
-         * multi-line color portions of this test aren't effective with those versions of ansicolor.
-         * However, we can't bump ansicolor to 0.6.2 or later because it requires Jenkins 2.145 or
-         * later, which is too high a bump for this plugin at present. When the minimum Jenkins
-         * version for this plugin is 2.145 or later, we should bump ansicolor to 0.6.2 or later
-         * to ensure we are effectively testing multi-line color support.
-         */
         project.setDefinition(
                 new CpsFlowDefinition(
                         "node {\n"

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -1,0 +1,151 @@
+package hudson.plugins.timestamper.pipeline;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.WebClientUtil;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlPreformattedText;
+import com.gargoylesoftware.htmlunit.html.HtmlSpan;
+import hudson.plugins.timestamper.TimestamperConfig;
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class PipelineTest {
+
+    private boolean originalAllPipelines;
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Before
+    public void setAllPipelines() {
+        TimestamperConfig config = TimestamperConfig.get();
+        originalAllPipelines = config.isAllPipelines();
+        config.setAllPipelines(true);
+    }
+
+    @After
+    public void restoreAllPipelines() {
+        TimestamperConfig config = TimestamperConfig.get();
+        config.setAllPipelines(originalAllPipelines);
+    }
+
+    @Test
+    public void globalDecoratorAnnotator() throws Exception {
+        WorkflowJob project = r.createProject(WorkflowJob.class);
+        /*
+         * TODO: ansicolor 0.6.1 and earlier don't properly support multi-line color output, so the
+         * multi-line color portions of this test aren't effective with those versions of ansicolor.
+         * However, we can't bump ansicolor to 0.6.2 or later because it requires Jenkins 2.145 or
+         * later, which is too high a bump for this plugin at present. When the minimum Jenkins
+         * version for this plugin is 2.145 or later, we should bump ansicolor to 0.6.2 or later
+         * to ensure we are effectively testing multi-line color support.
+         */
+        project.setDefinition(
+                new CpsFlowDefinition(
+                        "node {\n"
+                                + "  ansiColor('xterm') {\n"
+                                + "    echo 'foo'\n"
+                                + "    echo \"\\u001B[31mBeginning multi-line color\"\n"
+                                + "    echo \"More color\"\n"
+                                + "    echo \"Ending multi-line color\\u001B[39m\"\n"
+                                + "  }\n"
+                                + "}",
+                        true));
+        WorkflowRun build = r.buildAndAssertSuccess(project);
+        r.assertLogContains("foo", build);
+        r.assertLogContains("Beginning multi-line color", build);
+        r.assertLogContains("More color", build);
+        r.assertLogContains("Ending multi-line color", build);
+
+        /*
+         * Ensure that each line of the console log is decorated with a valid timestamp decoration.
+         * While doing so, save the raw timestamps for later comparison with the annotated console
+         * output.
+         */
+        List<String> rawTimestamps = new ArrayList<>();
+        for (String line : build.getLog(Integer.MAX_VALUE)) {
+            assertTrue(line, line.startsWith("["));
+            int end = line.indexOf(']');
+            assertEquals(line, 25, end);
+            assertNotNull(
+                    line, ZonedDateTime.parse(line.substring(1, end), GlobalDecorator.UTC_MILLIS));
+
+            rawTimestamps.add(line.substring(0, 26));
+        }
+
+        // Fetch the annotated console output.
+        HtmlPage page = r.createWebClient().getPage(build, "consoleFull");
+        WebClientUtil.waitForJSExec(page.getWebClient());
+        HtmlPreformattedText consoleOutput = page.getFirstByXPath("//pre[@class='console-output']");
+        String consoleText = consoleOutput.asText();
+
+        /*
+         * Ensure that each line of the console output is annotated with a timestamp and a raw
+         * timestamp. While doing so, save the raw timestamps for later comparison with the
+         * decorated console log.
+         */
+        List<String> annotatedLines =
+                new BufferedReader(new StringReader(consoleText))
+                        .lines()
+                        .collect(Collectors.toList());
+
+        List<String> annotatedTimestamps =
+                getTimestamps(consoleOutput, "//span[@class='timestamp']");
+        assertEquals(consoleText, annotatedLines.size(), annotatedTimestamps.size());
+
+        List<String> annotatedRawTimestamps =
+                getTimestamps(consoleOutput, "//span[contains(@style, 'display: none')]");
+        assertEquals(consoleText, annotatedLines.size(), annotatedRawTimestamps.size());
+
+        for (int i = 0; i < annotatedLines.size(); i++) {
+            String annotatedLine = annotatedLines.get(i);
+            String prefix = annotatedTimestamps.get(i) + annotatedRawTimestamps.get(i) + ' ';
+            assertTrue(
+                    String.format("annotatedLine: '%s', prefix: '%s'", annotatedLine, prefix),
+                    annotatedLine.startsWith(prefix));
+
+            /*
+             * The annotated console output contains "Terminated" lines which don't appear in the
+             * decorated console log. In order to do the raw timestamp comparison below, we ignore
+             * such lines.
+             */
+            if (annotatedLine.substring(prefix.length()).equals("Terminated")) {
+                annotatedTimestamps.remove(i);
+                annotatedRawTimestamps.remove(i);
+                annotatedLines.remove(i);
+            }
+        }
+
+        /*
+         * Ensure that the raw timestamps were correctly propagated from the decorated console log
+         * to the annotated console output.
+         */
+        assertEquals(rawTimestamps, annotatedRawTimestamps);
+    }
+
+    private static List<String> getTimestamps(
+            HtmlPreformattedText consoleOutput, String xpathExpr) {
+        List<String> timestamps = new ArrayList<>();
+
+        List<HtmlSpan> nodes = consoleOutput.getByXPath(xpathExpr);
+        for (HtmlSpan node : nodes) {
+            timestamps.add(node.getTextContent());
+        }
+
+        return timestamps;
+    }
+}

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -18,32 +18,24 @@ import java.util.stream.Collectors;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class PipelineTest {
 
-    private boolean originalAllPipelines;
-
-    @Rule public JenkinsRule r = new JenkinsRule();
-
     @Before
     public void setAllPipelines() {
         TimestamperConfig config = TimestamperConfig.get();
-        originalAllPipelines = config.isAllPipelines();
         config.setAllPipelines(true);
     }
 
-    @After
-    public void restoreAllPipelines() {
-        TimestamperConfig config = TimestamperConfig.get();
-        config.setAllPipelines(originalAllPipelines);
-    }
+    @Rule public JenkinsRule r = new JenkinsRule();
 
     @Test
+    @Issue("JENKINS-58102")
     public void globalDecoratorAnnotator() throws Exception {
         WorkflowJob project = r.createProject(WorkflowJob.class);
         project.setDefinition(


### PR DESCRIPTION
See [JENKINS-58102](https://issues.jenkins-ci.org/browse/JENKINS-58102). Fixes a bug introduced in jenkinsci/timestamper-plugin#25 that is only observable when `timestamper` is used with Pipeline and the multi-line escape sequence support introduced in jenkinsci/ansicolor-plugin#137. The problem is that `GlobalAnnotator` doesn't account for the `<span>` elements introduced by `ansicolor` when looking for timestamps to annotate. The fix is similar in approach to the existing code that accounts for the `<span>` elements introduced by Pipeline.

I wrote a new test that exercises this use case. When the test is executed against Jenkins 2.145 and `ansicolor` 0.6.2 (with the `src/main` changes from this PR reverted), it fails with the following stack trace:

```
15:23:35 [2019-06-23T22:23:35.328Z] Finished: SUCCESS expected:<21> but was:<17>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at hudson.plugins.timestamper.pipeline.PipelineTest.globalDecoratorAnnotator(PipelineTest.java:101)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:552)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

When the test is executed against Jenkins 2.145 and `ansicolor` 0.6.2 (with the `src/main` changes in this PR), the test passes.

~Unfortunately, I couldn't use `ansicolor` 0.6.2 in this PR because it requires Jenkins 2.145 or later, and [only 73% of `timestamper` users](https://stats.jenkins.io/pluginversions/timestamper.html) are on Jenkins 2.145 or later. Rather than drop support for 27% of the user base for the sake of one test, I compromised by using `ansicolor` 0.5.3, whose minimum Jenkins version is 2.121.2. When run against `ansicolor` 0.5.3, the new test isn't exercising the changes in `src/main` from this PR. However, it is exercising the bulk of the new logic introduced in jenkinsci/timestamper-plugin#25, which is still a net improvement from the state of affairs before this PR.~