### PR TITLE
Clean up generics

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
@@ -46,7 +46,7 @@ import hudson.plugins.timestamper.io.TimestampsReader;
  *
  * @author Steven G. Brown
  */
-public final class TimestampAnnotator extends ConsoleAnnotator<Object> {
+public final class TimestampAnnotator extends ConsoleAnnotator<Run<?, ?>> {
 
   private static final long serialVersionUID = 1L;
 
@@ -69,9 +69,7 @@ public final class TimestampAnnotator extends ConsoleAnnotator<Object> {
 
   /** {@inheritDoc} */
   @Override
-  public ConsoleAnnotator<Object> annotate(Object context, MarkupText text) {
-    Run<?, ?> build = (Run<?, ?>) context;
-
+  public ConsoleAnnotator<Run<?, ?>> annotate(Run<?, ?> build, MarkupText text) {
     try {
       if (timestampsReader == null) {
         ConsoleLogParser.Result logPosition = logParser.seek(build);

--- a/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3.java
@@ -41,17 +41,12 @@ import jenkins.YesNoMaybe;
  * @author Steven G. Brown
  */
 @Extension(dynamicLoadable = YesNoMaybe.YES)
-public final class TimestampAnnotatorFactory3 extends ConsoleAnnotatorFactory<Object> {
+public final class TimestampAnnotatorFactory3 extends ConsoleAnnotatorFactory<Run<?, ?>> {
 
   /** {@inheritDoc} */
   @Override
-  public ConsoleAnnotator<Object> newInstance(Object context) {
-    // Prior to Jenkins 2.145, context was the build class (see 7bc431f)
-    Class<?> contextClass = context instanceof Class<?> ? (Class<?>) context : context.getClass();
-    if (!Run.class.isAssignableFrom(contextClass)) {
-      return null; // something else
-    }
-    if (TimestampNote.useTimestampNotes(contextClass)) {
+  public ConsoleAnnotator<Run<?, ?>> newInstance(Run<?, ?> build) {
+    if (TimestampNote.useTimestampNotes(build.getClass())) {
       return null; // not using this system
     }
     StaplerRequest request = Stapler.getCurrentRequest();


### PR DESCRIPTION
#28 updated the Jenkins baseline from 2.121.1 to 2.150.3. As a result, we can now clean up some code that was only necessary to support Jenkins versions that didn't have jenkinsci/jenkins#3662.