### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/config.jelly
@@ -32,8 +32,8 @@ THE SOFTWARE.
     <f:entry title="${%Elapsed time format}" field="elapsedTimeFormat">
       <f:textbox/>
     </f:entry>
-    <f:entry title="${%Enabled for all Pipeline builds}" field="allPipelines">
-      <f:checkbox/>
+    <f:entry field="allPipelines">
+      <f:checkbox title="${%Enabled for all Pipeline builds}"/>
     </f:entry>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
[JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

The new UI looks like this:
![image](https://user-images.githubusercontent.com/2119212/64212272-cbabaf80-ce76-11e9-8870-fdf515204844.png)

Eventually the labels which are currently to the left of text boxes will be switched to being above them, which will reduce the amount of whitespace to the left of the checkboxes.