### PR TITLE
Generic pattern for third-party ConsoleAnnotators to avoid conflict with Timestamper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,14 +135,14 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-reflect</artifactId>
-      <version>1.7.4</version>
+      <version>2.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -193,6 +193,12 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
         <version>1.17</version>
+      </dependency>
+      <dependency>
+        <!-- require-upper-bound-deps between Mockito and PowerMock -->
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>3.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/hudson/plugins/timestamper/pipeline/GlobalAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/pipeline/GlobalAnnotator.java
@@ -86,6 +86,11 @@ public final class GlobalAnnotator extends ConsoleAnnotator<Object> {
         if (html.startsWith("<span style=\"color", start)) {
             start = html.indexOf('>', start) + 1;
         }
+        // Generic wrapper style that any other ConsoleAnnotator can use
+        // to avoid conflict with Timestamper's detection.
+        if (html.startsWith("<span data-timestamper", start)) {
+            start = html.indexOf('>', start) + 1;
+        }
         if (html.startsWith("[", start)) {
             int end = html.indexOf(']', start);
             if (end != -1) {

--- a/src/test/java/hudson/plugins/timestamper/pipeline/GlobalAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/GlobalAnnotatorTest.java
@@ -1,0 +1,163 @@
+package hudson.plugins.timestamper.pipeline;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+
+import com.google.common.base.Supplier;
+
+import hudson.MarkupText;
+import hudson.model.Run;
+import hudson.plugins.timestamper.format.ElapsedTimestampFormat;
+import hudson.plugins.timestamper.format.TimestampFormat;
+import hudson.plugins.timestamper.format.TimestampFormatProvider;
+
+/**
+ * 
+ * @author awitt
+ *
+ */
+public class GlobalAnnotatorTest {
+    
+    /**
+     * {@link GlobalAnnotator} will determine build start time by {@link Run#getStartTimeInMillis()}
+     */
+    protected Run<?,?> run;
+    
+    /**
+     * The {@link GlobalAnnotator} under test
+     */
+    protected GlobalAnnotator annotator;
+    
+    @Before
+    public void setUp() {
+
+        run = mock( Run.class );
+        
+        annotator = new GlobalAnnotator();
+        
+        Whitebox.setInternalState(TimestampFormatProvider.class, new Supplier<TimestampFormat>() {
+
+            @Override
+            public TimestampFormat get() {
+                return new ElapsedTimestampFormat( "'<b>'HH:mm:ss.S'</b> '" ); // default Elapsed timestamp format
+            }
+            
+        });
+    }
+
+    @Test
+    public void testTimestampsWhenNotWrapped() {
+        
+        // Timestamps should be correctly identified in a "regular" log line.
+        
+        when( run.getStartTimeInMillis() )
+        .thenReturn( 1572023430 * 1000L ); // 2019-10-25T17:10:30.000
+        
+        String log = "[2019-10-25T17:10:30.374Z] Raw log line";
+        
+        MarkupText text = new MarkupText( log );
+        
+        annotator.annotate( run, text );
+        
+        assertEquals(
+            "Timestamps should be correctly identified in a regular log line.",
+            "<span class=\"timestamp\"><b>00:00:00.374</b> </span><span style=\"display: none\">[2019-10-25T17:10:30.374Z]</span> Raw log line",
+            text.toString( true ) );
+    }
+    
+    @Test
+    public void testTimestampsWhenWrapped() {
+        
+        // Timestamps should be correctly identified in log line wrapped in HTML by some other ConsoleAnnotator
+        
+        when( run.getStartTimeInMillis() )
+        .thenReturn( 1572023430 * 1000L ); // 2019-10-25T17:10:30.000
+        
+        String log = "[2019-10-25T17:10:30.374Z] Raw log line";
+        
+        MarkupText text = new MarkupText( log );
+        text.wrapBy("<span data-timestamper style='who-knows'>", "</span>"); // as some other ConsoleAnnotator might
+        
+        annotator.annotate( run, text );
+        
+        assertEquals(
+            "Timestamps should be correctly identified in a log line that another ConsoleAnnotator has wrapped in HTML tags.",
+            "<span class=\"timestamp\"><b>00:00:00.374</b> </span><span data-timestamper style='who-knows'><span style=\"display: none\">[2019-10-25T17:10:30.374Z]</span> Raw log line</span>",
+            text.toString( true ) );
+        
+    }
+    
+    @Test
+    public void testTimestampsWhenWrappedWithoutSpecialCase() {
+        
+        // Timestamps should be incorrectly identified in log line wrapped in HTML by some other ConsoleAnnotator
+        // when that annotator doesn't know about the special-case workaround
+        
+        when( run.getStartTimeInMillis() )
+        .thenReturn( 1572023430 * 1000L ); // 2019-10-25T17:10:30.000
+        
+        String log = "[2019-10-25T17:10:30.374Z] Raw log line";
+        
+        MarkupText text = new MarkupText( log );
+        text.wrapBy("<span style='who-knows'>", "</span>"); // as some other ConsoleAnnotator might
+        
+        annotator.annotate( run, text );
+        
+        assertEquals(
+            "Timestamp identification will regrettably fail in a log line that another ConsoleAnnotator has wrapped in HTML tags without using the special workaround.",
+            "<span style='who-knows'>[2019-10-25T17:10:30.374Z] Raw log line</span>",
+            text.toString( true ) );
+        
+    }
+    
+    @Test
+    public void testTimestampsWhenDoubleWrapped() {
+        
+        // Timestamps should be incorrectly identified in log line wrapped in HTML by some other ConsoleAnnotator
+        // when that annotator doesn't know about the special-case workaround
+        
+        when( run.getStartTimeInMillis() )
+        .thenReturn( 1572023430 * 1000L ); // 2019-10-25T17:10:30.000
+        
+        String log = "[2019-10-25T17:10:30.374Z] Raw log line";
+        
+        MarkupText text = new MarkupText( log );
+        text.wrapBy("<span data-timestamper style='who-knows'>", "</span>"); // as some other ConsoleAnnotator might
+        text.wrapBy("<span data-timestamper style='something-else'>", "</span>"); // as some third ConsoleAnnotator might
+        
+        annotator.annotate( run, text );
+        
+        assertEquals(
+            "Timestamp identification will regrettably fail in a log line wrapped by two other ConsoleAnnotators, both of whom tried to use this workaround.",
+            "<span data-timestamper style='who-knows'><span data-timestamper style='something-else'>[2019-10-25T17:10:30.374Z] Raw log line</span></span>",
+            text.toString( true ) );
+        
+    }
+    
+    @Test
+    public void testTimestampsWhenHTMLIsPartOfTheLog() {
+        
+        // Timestamps should be correctly detected when HTML is part of the actual log output.
+        
+        when( run.getStartTimeInMillis() )
+        .thenReturn( 1572023430 * 1000L ); // 2019-10-25T17:10:30.000
+        
+        String log = "[2019-10-25T17:10:30.374Z] <span style='who-knows'>content</span> remainder";
+        
+        MarkupText text = new MarkupText( log );
+        
+        annotator.annotate( run, text );
+        
+        assertEquals(
+            "Timestamps should be correctly identified when the actual log line contains HTML tags.",
+            "<span class=\"timestamp\"><b>00:00:00.374</b> </span><span style=\"display: none\">[2019-10-25T17:10:30.374Z]</span> &lt;span style='who-knows'&gt;content&lt;/span&gt; remainder",
+            text.toString( true ) );
+        
+    }
+
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
_For your consideration:_

I maintain code internal to my company that wraps console log lines in HTML. After the upgrade from Timestamper 1.8, timestamps stopped rendering properly. It turns out this is because the new Timestamper expected console log lines to start with a square bracket-enclosed timestamp, _or_ one of two special-cased exclusion patterns.

My code wrapped log lines in an HTML `<span ...>` and didn't match either special case.

I need an exclusion to restore compatibility with Timestamper, too, but my code isn't publicly-available (yet?), so it doesn't make sense to add one more special case just for me.

Here, I have added a _general-case_ special-case that any third-party ConsoleAnnotator could apply to its wrapping of console log lines to avoid conflict Timestamper's detection.

Using [HTML5 data-attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes): Just begin your own wrapping with `<span data-timestamper ...>`, and Timestamper will correctly detect the `[actual timestamp]` and render the timestamps in the WebUI.

This is imperfect, of course, since there's no way for one ConsoleAnnotator to know what may annotate a line before or after it, and if two annotators both try to do this, they'll produce `<span data-timestamper ...><span data-timestamper ...>[actual timestamp] ...</span></span>` which will again, not work.

So, I'm not sure that this is the _best_ solution to the core problem that:

> By baking timestamps into "real" build log text and expecting them to be present, Timestamper is incompatible with 
> 1. other ConsoleAnnotators that wrap log lines with HTML, and have not been special-cased
> 2. Jenkins installations with multiple ConsoleAnnotators that wrap log lines with HTML

I sent an e-mail to the jenkinsci-users mailling list as well, hoping to start or find discussion about the ramifications of the 1.9 change on other folks' ConsoleAnnotator usage.

*Note:* I added unit-tests for this behavior, but the `master` branch tests wouldn't even complete on my local machine, and the full test-suite (not my new tests) produced new error messages after my changes. I'll see what the PR-validation builds report, and debug the tests from there.