### PR TITLE
Create .mailmap for git shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Steven G Brown <StevenGBrown@gmail.com>
+Steven G Brown <StevenGBrown@gmail.com> <StevenGBrown@dev.java.net>
+Steven G Brown <StevenGBrown@gmail.com> <stevengbrown@ubuntu-steve.(none)>


### PR DESCRIPTION
Steven G Brown has several emails and names in the history:

    $ git shortlog -s -e|grep -i steven
       230	Steven Brown <StevenGBrown@gmail.com>
        18	StevenGBrown <StevenGBrown@dev.java.net>
        81	StevenGBrown <StevenGBrown@gmail.com>
        38	StevenGBrown <stevengbrown@ubuntu-steve.(none)>

The provided .mailmap instructs git to fix up those aliases. After:

    $ git shortlog -s -e|grep -i steven
       367	Steven G Brown <StevenGBrown@gmail.com>
