### PR TITLE
[JENKINS-55167] Add Java 11 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin platforms: ['linux']
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.16</version>
+      <version>2.19</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>2.4.6</version>
+      <version>3.1.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.26</version>
+      <version>2.32</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/timestamper/TimestamperBuildWrapper.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestamperBuildWrapper.java
@@ -23,7 +23,6 @@
  */
 package hudson.plugins.timestamper;
 
-import com.google.common.base.Optional;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -43,6 +42,7 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.YesNoMaybe;
@@ -104,7 +104,7 @@ public final class TimestamperBuildWrapper extends SimpleBuildWrapper {
       if (useTimestampNotes) {
         return new TimestampNotesOutputStream(logger, buildStartTime);
       }
-      Optional<MessageDigest> digest = Optional.absent();
+      Optional<MessageDigest> digest = Optional.empty();
       try {
         digest = Optional.of(MessageDigest.getInstance("SHA-1"));
       } catch (NoSuchAlgorithmException ex) {

--- a/src/main/java/hudson/plugins/timestamper/action/PrecisionTimestampFormat.java
+++ b/src/main/java/hudson/plugins/timestamper/action/PrecisionTimestampFormat.java
@@ -25,9 +25,9 @@ package hudson.plugins.timestamper.action;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import hudson.plugins.timestamper.Timestamp;
+import java.util.function.Function;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang.builder.ToStringBuilder;

--- a/src/main/java/hudson/plugins/timestamper/action/TimestampsActionOutput.java
+++ b/src/main/java/hudson/plugins/timestamper/action/TimestampsActionOutput.java
@@ -25,9 +25,7 @@ package hudson.plugins.timestamper.action;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import hudson.model.Run;
 import hudson.plugins.timestamper.Timestamp;
 import hudson.plugins.timestamper.io.LogFileReader;
@@ -40,7 +38,9 @@ import java.io.StringReader;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.TimeZone;
+import java.util.function.Function;
 import org.apache.commons.lang.time.DurationFormatUtils;
 
 /**
@@ -114,7 +114,7 @@ public class TimestampsActionOutput {
     Reader reader =
         new Reader() {
           int linesRead;
-          Optional<Integer> endLine = Optional.absent();
+          Optional<Integer> endLine = Optional.empty();
           boolean started;
 
           @Override
@@ -188,7 +188,7 @@ public class TimestampsActionOutput {
             }
 
             if (!timestamp.isPresent() && !logFileLine.isPresent()) {
-              return Optional.absent();
+              return Optional.empty();
             }
             return Optional.of(result);
           }
@@ -207,7 +207,7 @@ public class TimestampsActionOutput {
 
     private final LogFileReader logFileReader;
 
-    private Optional<Integer> lineCount = Optional.absent();
+    private Optional<Integer> lineCount = Optional.empty();
 
     LineCountSupplier(LogFileReader logFileReader) {
       this.logFileReader = checkNotNull(logFileReader);

--- a/src/main/java/hudson/plugins/timestamper/action/TimestampsActionQuery.java
+++ b/src/main/java/hudson/plugins/timestamper/action/TimestampsActionQuery.java
@@ -25,8 +25,6 @@ package hudson.plugins.timestamper.action;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import hudson.plugins.timestamper.Timestamp;
 import hudson.plugins.timestamper.format.ElapsedTimestampFormat;
@@ -37,6 +35,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 import org.apache.commons.lang.LocaleUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
@@ -55,7 +55,7 @@ public final class TimestampsActionQuery {
    */
   public static TimestampsActionQuery create(String query) {
     int startLine = 0;
-    Optional<Integer> endLine = Optional.absent();
+    Optional<Integer> endLine = Optional.empty();
     List<Function<Timestamp, String>> timestampFormats =
         new ArrayList<Function<Timestamp, String>>();
     boolean appendLogLine = false;
@@ -63,7 +63,7 @@ public final class TimestampsActionQuery {
 
     List<QueryParameter> queryParameters = readQueryString(query);
 
-    Optional<String> timeZoneId = Optional.absent();
+    Optional<String> timeZoneId = Optional.empty();
     Locale locale = Locale.getDefault();
     for (QueryParameter parameter : queryParameters) {
       if (parameter.name.equalsIgnoreCase("timeZone")) {

--- a/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/TimestampAnnotator.java
@@ -25,7 +25,6 @@ package hudson.plugins.timestamper.annotator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Optional;
 import hudson.MarkupText;
 import hudson.console.ConsoleAnnotator;
 import hudson.model.Run;
@@ -34,6 +33,7 @@ import hudson.plugins.timestamper.format.TimestampFormat;
 import hudson.plugins.timestamper.format.TimestampFormatProvider;
 import hudson.plugins.timestamper.io.TimestampsReader;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;

--- a/src/main/java/hudson/plugins/timestamper/format/SystemTimestampFormat.java
+++ b/src/main/java/hudson/plugins/timestamper/format/SystemTimestampFormat.java
@@ -23,10 +23,11 @@
  */
 package hudson.plugins.timestamper.format;
 
-import com.google.common.base.Optional;
 import hudson.plugins.timestamper.Timestamp;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.TimeZone;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -88,7 +89,7 @@ public final class SystemTimestampFormat extends TimestampFormat {
   /** {@inheritDoc} */
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(format, timeZoneId);
+    return Objects.hash(format, timeZoneId);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/hudson/plugins/timestamper/format/TimestampFormat.java
+++ b/src/main/java/hudson/plugins/timestamper/format/TimestampFormat.java
@@ -23,9 +23,9 @@
  */
 package hudson.plugins.timestamper.format;
 
-import com.google.common.base.Function;
 import hudson.MarkupText;
 import hudson.plugins.timestamper.Timestamp;
+import java.util.function.Function;
 
 /**
  * Format for displaying time-stamps.

--- a/src/main/java/hudson/plugins/timestamper/format/TimestampFormatProvider.java
+++ b/src/main/java/hudson/plugins/timestamper/format/TimestampFormatProvider.java
@@ -23,10 +23,10 @@
  */
 package hudson.plugins.timestamper.format;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Supplier;
 import hudson.plugins.timestamper.TimestamperConfig;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Supplier;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import org.kohsuke.stapler.Stapler;
@@ -40,9 +40,7 @@ import org.kohsuke.stapler.StaplerRequest;
 public class TimestampFormatProvider {
 
   private static Supplier<TimestampFormat> SUPPLIER =
-      new Supplier<TimestampFormat>() {
-        @Override
-        public TimestampFormat get() {
+      () -> {
           TimestamperConfig config = TimestamperConfig.get();
           StaplerRequest request = Stapler.getCurrentRequest();
           if (config == null || request == null) {
@@ -53,7 +51,6 @@ public class TimestampFormatProvider {
               config.getElapsedTimeFormat(),
               request,
               Locale.getDefault());
-        }
       };
 
   /**
@@ -98,7 +95,7 @@ public class TimestampFormatProvider {
       return EmptyTimestampFormat.INSTANCE;
     } else {
       // "system", no mode cookie, or unrecognised mode cookie
-      Optional<String> timeZoneId = Optional.absent();
+      Optional<String> timeZoneId = Optional.empty();
       if (local != null && local.booleanValue()) {
         try {
           String localTimeZoneId = convertOffsetToTimeZoneId(offset);

--- a/src/main/java/hudson/plugins/timestamper/io/LogFileReader.java
+++ b/src/main/java/hudson/plugins/timestamper/io/LogFileReader.java
@@ -25,7 +25,6 @@ package hudson.plugins.timestamper.io;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Optional;
 import com.google.common.io.CountingInputStream;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.console.ConsoleNote;
@@ -38,6 +37,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Scanner;
 import javax.annotation.CheckForNull;
 import org.apache.commons.io.IOUtils;
@@ -84,7 +84,7 @@ public class LogFileReader implements Closeable {
       while (true) {
         index = ConsoleNote.findPreamble(bytes, index, length - index);
         if (index == -1) {
-          return Optional.absent();
+          return Optional.empty();
         }
         CountingInputStream inputStream =
             new CountingInputStream(new ByteArrayInputStream(bytes, index, length - index));
@@ -146,12 +146,12 @@ public class LogFileReader implements Closeable {
   /**
    * Read the next line from the log file.
    *
-   * @return the next line, or {@link Optional#absent()} if there are no more to read
+   * @return the next line, or {@link Optional#empty()} if there are no more to read
    * @throws IOException
    */
   public Optional<Line> nextLine() throws IOException {
     if (!build.getLogFile().exists()) { // TODO JENKINS-54128 rather use getLogText
-      return Optional.absent();
+      return Optional.empty();
     }
     if (reader == null) {
       reader = new Scanner(build.getLogReader());
@@ -161,7 +161,7 @@ public class LogFileReader implements Closeable {
     try {
       line = reader.next();
     } catch (NoSuchElementException e) {
-      return Optional.absent();
+      return Optional.empty();
     }
     return Optional.of(new Line(line, build));
   }

--- a/src/main/java/hudson/plugins/timestamper/io/TimeShiftsReader.java
+++ b/src/main/java/hudson/plugins/timestamper/io/TimeShiftsReader.java
@@ -23,7 +23,6 @@
  */
 package hudson.plugins.timestamper.io;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CountingInputStream;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -36,6 +35,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.CheckForNull;
 
 /**
@@ -67,7 +67,7 @@ class TimeShiftsReader implements Serializable {
   /**
    * Get the time recorded for the given time-stamp entry.
    *
-   * @return the recorded number of milliseconds since the epoch, or {@link Optional#absent()} if no
+   * @return the recorded number of milliseconds since the epoch, or {@link Optional#empty()} if no
    *     time shift was recorded for that time-stamp entry
    * @throws IOException
    */
@@ -75,7 +75,7 @@ class TimeShiftsReader implements Serializable {
     if (timeShifts == null) {
       timeShifts = ImmutableMap.copyOf(readTimeShifts());
     }
-    return Optional.fromNullable(timeShifts.get(timestampEntry));
+    return Optional.ofNullable(timeShifts.get(timestampEntry));
   }
 
   private Map<Long, Long> readTimeShifts() throws IOException {

--- a/src/main/java/hudson/plugins/timestamper/io/TimestampsReader.java
+++ b/src/main/java/hudson/plugins/timestamper/io/TimestampsReader.java
@@ -23,7 +23,6 @@
  */
 package hudson.plugins.timestamper.io;
 
-import com.google.common.base.Optional;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingInputStream;
 import hudson.model.Run;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Optional;
 import javax.annotation.CheckForNull;
 import org.apache.commons.io.IOUtils;
 
@@ -112,19 +112,19 @@ public class TimestampsReader implements Serializable, Closeable {
   /**
    * Read the next time-stamp.
    *
-   * @return the next time-stamp, or {@link Optional#absent()} if there are no more to read
+   * @return the next time-stamp, or {@link Optional#empty()} if there are no more to read
    * @throws IOException
    */
   public Optional<Timestamp> read() throws IOException {
     if (inputStream == null) {
       if (!timestampsFile.isFile()) {
-        return Optional.absent();
+        return Optional.empty();
       }
       inputStream = new FileInputStream(timestampsFile);
       ByteStreams.skipFully(inputStream, filePointer);
       inputStream = new BufferedInputStream(inputStream);
     }
-    Optional<Timestamp> timestamp = Optional.absent();
+    Optional<Timestamp> timestamp = Optional.empty();
     if (filePointer < timestampsFile.length()) {
       timestamp = Optional.of(readNext(inputStream));
     }
@@ -149,7 +149,7 @@ public class TimestampsReader implements Serializable, Closeable {
     long elapsedMillisDiff = Varint.read(countingInputStream);
 
     elapsedMillis += elapsedMillisDiff;
-    millisSinceEpoch = timeShiftsReader.getTime(entry).or(millisSinceEpoch + elapsedMillisDiff);
+    millisSinceEpoch = timeShiftsReader.getTime(entry).orElse(millisSinceEpoch + elapsedMillisDiff);
     filePointer += countingInputStream.getCount();
     entry++;
     return new Timestamp(elapsedMillis, millisSinceEpoch);

--- a/src/main/java/hudson/plugins/timestamper/io/TimestampsWriter.java
+++ b/src/main/java/hudson/plugins/timestamper/io/TimestampsWriter.java
@@ -26,7 +26,6 @@ package hudson.plugins.timestamper.io;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Optional;
 import com.google.common.io.Files;
 import hudson.model.Run;
 import java.io.Closeable;
@@ -38,6 +37,7 @@ import java.io.OutputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
+import java.util.Optional;
 import javax.annotation.CheckForNull;
 
 /**
@@ -67,7 +67,7 @@ public class TimestampsWriter implements Closeable {
    * @throws IOException
    */
   public TimestampsWriter(Run<?, ?> build) throws IOException {
-    this(build, Optional.absent());
+    this(build, Optional.empty());
   }
 
   /**

--- a/src/test/java/hudson/plugins/timestamper/TimestampNoteTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestampNoteTest.java
@@ -29,12 +29,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Supplier;
 import hudson.MarkupText;
 import hudson.model.Run;
 import hudson.plugins.timestamper.format.TimestampFormat;
 import hudson.plugins.timestamper.format.TimestampFormatProvider;
 import java.util.Arrays;
+import java.util.function.Supplier;
 import org.apache.commons.lang.SerializationUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.junit.After;

--- a/src/test/java/hudson/plugins/timestamper/action/TimestampsActionQueryTest.java
+++ b/src/test/java/hudson/plugins/timestamper/action/TimestampsActionQueryTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -40,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -60,9 +60,9 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class TimestampsActionQueryTest {
 
-  private static final Optional<Integer> NO_ENDLINE = Optional.absent();
+  private static final Optional<Integer> NO_ENDLINE = Optional.empty();
 
-  private static final Optional<String> NO_TIMEZONE = Optional.absent();
+  private static final Optional<String> NO_TIMEZONE = Optional.empty();
 
   private static final TimestampsActionQuery DEFAULT =
       new TimestampsActionQuery(
@@ -209,7 +209,7 @@ public class TimestampsActionQueryTest {
     // Start line and end line
     List<Optional<Integer>> lineValues =
         ImmutableList.of(
-            Optional.of(-1), Optional.of(0), Optional.of(1), Optional.absent());
+            Optional.of(-1), Optional.of(0), Optional.of(1), Optional.empty());
     for (Optional<Integer> startLine : lineValues) {
       for (Optional<Integer> endLine : lineValues) {
         List<String> params = new ArrayList<String>();
@@ -226,7 +226,7 @@ public class TimestampsActionQueryTest {
               new Object[] {
                 query,
                 new TimestampsActionQuery(
-                    startLine.or(0), endLine, DEFAULT.timestampFormats, false, false)
+                    startLine.orElse(0), endLine, DEFAULT.timestampFormats, false, false)
               });
         }
       }

--- a/src/test/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Supplier;
 import hudson.MarkupText;
 import hudson.console.ConsoleAnnotator;
 import hudson.model.Run;
@@ -44,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.commons.lang.SerializationUtils;
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/hudson/plugins/timestamper/format/SystemTimestampFormatTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/SystemTimestampFormatTest.java
@@ -26,9 +26,9 @@ package hudson.plugins.timestamper.format;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.base.Optional;
 import hudson.plugins.timestamper.Timestamp;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.TimeZone;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -70,7 +70,7 @@ public class SystemTimestampFormatTest {
     String systemTimeFormat = "HH:mm:ss";
     Timestamp timestamp = new Timestamp(123, 42000);
     assertThat(
-        new SystemTimestampFormat(systemTimeFormat, Optional.absent(), Locale.ENGLISH)
+        new SystemTimestampFormat(systemTimeFormat, Optional.empty(), Locale.ENGLISH)
             .apply(timestamp),
         is("00:00:42"));
   }
@@ -83,7 +83,7 @@ public class SystemTimestampFormatTest {
     String systemTimeFormat = "HH:mm:ss";
     Timestamp timestamp = new Timestamp(123, 42000);
     assertThat(
-        new SystemTimestampFormat(systemTimeFormat, Optional.absent(), Locale.ENGLISH)
+        new SystemTimestampFormat(systemTimeFormat, Optional.empty(), Locale.ENGLISH)
             .apply(timestamp),
         is("01:00:42"));
   }
@@ -96,7 +96,7 @@ public class SystemTimestampFormatTest {
     String systemTimeFormat = "HH:mm:ss";
     Timestamp timestamp = new Timestamp(123, 42000);
     assertThat(
-        new SystemTimestampFormat(systemTimeFormat, Optional.absent(), Locale.ENGLISH)
+        new SystemTimestampFormat(systemTimeFormat, Optional.empty(), Locale.ENGLISH)
             .apply(timestamp),
         is("02:00:42"));
   }
@@ -131,7 +131,7 @@ public class SystemTimestampFormatTest {
     String systemTimeFormat = "EEEE, d MMMM";
     Timestamp timestamp = new Timestamp(123, 42000);
     assertThat(
-        new SystemTimestampFormat(systemTimeFormat, Optional.absent(), Locale.ENGLISH)
+        new SystemTimestampFormat(systemTimeFormat, Optional.empty(), Locale.ENGLISH)
             .apply(timestamp),
         is("Thursday, 1 January"));
   }
@@ -142,7 +142,7 @@ public class SystemTimestampFormatTest {
     String systemTimeFormat = "EEEE, d MMMM";
     Timestamp timestamp = new Timestamp(123, 42000);
     assertThat(
-        new SystemTimestampFormat(systemTimeFormat, Optional.absent(), Locale.GERMAN)
+        new SystemTimestampFormat(systemTimeFormat, Optional.empty(), Locale.GERMAN)
             .apply(timestamp),
         is("Donnerstag, 1 Januar"));
   }
@@ -152,7 +152,7 @@ public class SystemTimestampFormatTest {
   public void testGetPlainTextUrl() {
     SystemTimestampFormat format =
         new SystemTimestampFormat(
-            "'<b>'HH:mm:ss'</b> '", Optional.absent(), Locale.ENGLISH);
+            "'<b>'HH:mm:ss'</b> '", Optional.empty(), Locale.ENGLISH);
     assertThat(format.getPlainTextUrl(), is("timestamps/?time=HH:mm:ss&appendLog&locale=en"));
   }
 
@@ -161,7 +161,7 @@ public class SystemTimestampFormatTest {
   public void testGetPlainTextUrl_excessWhitespace() {
     SystemTimestampFormat format =
         new SystemTimestampFormat(
-            " ' <b> ' HH:mm:ss ' </b> ' ", Optional.absent(), Locale.ENGLISH);
+            " ' <b> ' HH:mm:ss ' </b> ' ", Optional.empty(), Locale.ENGLISH);
     assertThat(format.getPlainTextUrl(), is("timestamps/?time=HH:mm:ss&appendLog&locale=en"));
   }
 

--- a/src/test/java/hudson/plugins/timestamper/format/TimestampFormatProviderTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/TimestampFormatProviderTest.java
@@ -28,10 +28,10 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Optional;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import javax.servlet.http.Cookie;
@@ -112,7 +112,7 @@ public class TimestampFormatProviderTest {
   }
 
   private static SystemTimestampFormat system() {
-    return new SystemTimestampFormat(SYSTEM_TIME_FORMAT, Optional.absent(), Locale.ENGLISH);
+    return new SystemTimestampFormat(SYSTEM_TIME_FORMAT, Optional.empty(), Locale.ENGLISH);
   }
 
   private static SystemTimestampFormat system(String timeZoneId) {

--- a/src/test/java/hudson/plugins/timestamper/io/LogFileReaderTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/LogFileReaderTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import hudson.PluginManager;
@@ -48,6 +47,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.zip.GZIPOutputStream;
 import jenkins.model.Jenkins;
 import org.apache.commons.codec.binary.Base64OutputStream;
@@ -161,7 +161,7 @@ public class LogFileReaderTest {
     assertThat("texts", texts, is(expectedTexts));
 
     List<Optional<Timestamp>> expectedTimestamps =
-        ImmutableList.of(Optional.absent(), Optional.of(timestamp));
+        ImmutableList.of(Optional.empty(), Optional.of(timestamp));
     assertThat("timestamps", timestamps, is(expectedTimestamps));
   }
 
@@ -169,7 +169,7 @@ public class LogFileReaderTest {
   @Test
   public void testNextLine_noLogFile() throws Exception {
     when(build.getLogFile()).thenReturn(nonExistantFile);
-    assertThat(logFileReader.nextLine(), is(Optional.<Line>absent()));
+    assertThat(logFileReader.nextLine(), is(Optional.empty()));
   }
 
   /** @throws Exception */
@@ -209,7 +209,7 @@ public class LogFileReaderTest {
 
     List<Optional<Timestamp>> expectedTimestamps = new ArrayList<Optional<Timestamp>>();
     for (int i = 0; i < logFileContents.size(); i++) {
-      expectedTimestamps.add(Optional.absent());
+      expectedTimestamps.add(Optional.empty());
     }
     assertThat(timestamps, is(expectedTimestamps));
   }

--- a/src/test/java/hudson/plugins/timestamper/io/TimestampsIOTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/TimestampsIOTest.java
@@ -28,9 +28,9 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Optional;
 import hudson.model.Run;
 import hudson.plugins.timestamper.Timestamp;
+import java.util.Optional;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/hudson/plugins/timestamper/io/TimestampsReaderTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/TimestampsReaderTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Optional;
 import hudson.model.Run;
 import hudson.plugins.timestamper.Timestamp;
 import java.io.File;
@@ -39,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang.SerializationUtils;
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/hudson/plugins/timestamper/io/TimestampsWriterTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/TimestampsWriterTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Optional;
 import com.google.common.io.CountingInputStream;
 import com.google.common.io.Files;
 import hudson.model.Run;
@@ -44,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;


### PR DESCRIPTION
Downstream of #41. This change adds Java 11 support in the `Jenkinsfile` by using `buildPlugin.recommendedConfigurations()`. In order for the Java 11 build and tests to pass, I had to update various Pipeline plugins in `pom.xml`. I also had to update `nl.jqno.equalsverifier` to a newer version that supports Java 11.

Unfortunately, the newest version of `nl.jqno.equalsverifier` also depends on a recent version of Guava at runtime, which we don't have in the Jenkins project. Upon looking into this further, I realized that I could work around the Guava issue by not using Guava in any fields being tested with `nl.jqno.equalsverifier`. The reason this works is that `nl.jqno.equalsverifier` lazy-loads its Guava functionality, and if no fields use Guava then the lazy-loading never occurs. The only relevant fields were using types like `Optional`, `Function`, and `Supplier`. By migrating these fields from Guava functional types to Java 8 functional types, I got the `nl.jqno.equalsverifier` tests to pass without ever loading the problematic Guava functionality.