### PR TITLE
Add integration test for TimestamperBuildWrapper

### DIFF
--- a/src/test/java/hudson/plugins/timestamper/TimestamperIntegrationTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperIntegrationTest.java
@@ -1,7 +1,6 @@
 package hudson.plugins.timestamper;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import com.gargoylesoftware.htmlunit.WebClientUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -60,9 +59,8 @@ public class TimestamperIntegrationTest {
         for (int i = 0; i < annotatedLines.size(); i++) {
             String annotatedLine = annotatedLines.get(i);
             String prefix = annotatedTimestamps.get(i) + ' ';
-            assertTrue(
-                    String.format("annotatedLine: '%s', prefix: '%s'", annotatedLine, prefix),
-                    annotatedLine.startsWith(prefix));
+            String unannotatedLine = unannotatedLines.get(i);
+            assertEquals(annotatedLine, prefix + unannotatedLine);
         }
     }
 

--- a/src/test/java/hudson/plugins/timestamper/TimestamperIntegrationTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperIntegrationTest.java
@@ -1,0 +1,80 @@
+package hudson.plugins.timestamper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.WebClientUtil;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlPreformattedText;
+import com.gargoylesoftware.htmlunit.html.HtmlSpan;
+import hudson.Functions;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class TimestamperIntegrationTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void buildWrapper() throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        project.getBuildersList()
+                .add(Functions.isWindows() ? new BatchFile("echo foo") : new Shell("echo foo"));
+        project.getBuildWrappersList().add(new TimestamperBuildWrapper());
+        FreeStyleBuild build = r.buildAndAssertSuccess(project);
+        r.assertLogContains("foo", build);
+
+        // Fetch the unannotated console output.
+        List<String> unannotatedLines = build.getLog(Integer.MAX_VALUE);
+
+        // Fetch the annotated console output.
+        HtmlPage page = r.createWebClient().getPage(build, "consoleFull");
+        WebClientUtil.waitForJSExec(page.getWebClient());
+        HtmlPreformattedText consoleOutput = page.getFirstByXPath("//pre[@class='console-output']");
+        String consoleText = consoleOutput.asText();
+        List<String> annotatedLines =
+                new BufferedReader(new StringReader(consoleText))
+                        .lines()
+                        .collect(Collectors.toList());
+        assertEquals(consoleText, unannotatedLines.size(), annotatedLines.size());
+
+        // Ensure that each line of the annotated console output has a timestamp.
+        List<String> annotatedTimestamps =
+                getTimestamps(consoleOutput, "//span[@class='timestamp']");
+        assertEquals(consoleText, annotatedLines.size(), annotatedTimestamps.size());
+        for (String annotatedTimestamp : annotatedTimestamps) {
+            assertEquals(annotatedTimestamp, 8, annotatedTimestamp.length());
+        }
+
+        // Ensure that each line is annotated with nothing other than the timestamp.
+        for (int i = 0; i < annotatedLines.size(); i++) {
+            String annotatedLine = annotatedLines.get(i);
+            String prefix = annotatedTimestamps.get(i) + ' ';
+            assertTrue(
+                    String.format("annotatedLine: '%s', prefix: '%s'", annotatedLine, prefix),
+                    annotatedLine.startsWith(prefix));
+        }
+    }
+
+    private static List<String> getTimestamps(
+            HtmlPreformattedText consoleOutput, String xpathExpr) {
+        List<String> timestamps = new ArrayList<>();
+
+        List<HtmlSpan> nodes = consoleOutput.getByXPath(xpathExpr);
+        for (HtmlSpan node : nodes) {
+            timestamps.add(node.getTextContent().trim());
+        }
+
+        return timestamps;
+    }
+}


### PR DESCRIPTION
Doubles integration test coverage for this plugin by adding an integration test that actually runs Jenkins in order to exercise `TimestamperBuildWrapper`. I verified with JaCoCo that this increases integration test coverage for this plugin from ~15% to ~34%.