### PR TITLE
Add tests for JENKINS-60007

### DIFF
--- a/src/test/java/hudson/plugins/timestamper/TimestamperApiTestUtil.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperApiTestUtil.java
@@ -17,9 +17,8 @@ import java.util.stream.Collectors;
 
 public class TimestamperApiTestUtil {
 
-    public static void timestamperApi(Run<?, ?> build) throws IOException {
-        List<String> unstampedLines = build.getLog(Integer.MAX_VALUE);
-
+    public static void timestamperApi(Run<?, ?> build, List<String> unstampedLines)
+            throws IOException {
         time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", false);
         time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", true);
 

--- a/src/test/java/hudson/plugins/timestamper/TimestamperApiTestUtil.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperApiTestUtil.java
@@ -1,0 +1,111 @@
+package hudson.plugins.timestamper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import hudson.model.Run;
+import hudson.plugins.timestamper.action.TimestampsActionOutput;
+import hudson.plugins.timestamper.action.TimestampsActionQuery;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TimestamperApiTestUtil {
+
+    public static void timestamperApi(Run<?, ?> build) throws IOException {
+        List<String> unstampedLines = build.getLog(Integer.MAX_VALUE);
+
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", false);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", true);
+
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, false);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, true);
+
+        currentTime(build, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "UTC");
+    }
+
+    private static void time(
+            Run<?, ?> build,
+            List<String> unstampedLines,
+            String pattern,
+            int patternLength,
+            String timezone,
+            boolean appendLog)
+            throws IOException {
+        List<String> results =
+                getQueryResults(
+                        build,
+                        String.format(
+                                "time=%s&timeZone=%s%s",
+                                pattern, timezone, appendLog ? "&appendLog" : ""));
+        assertEquals(unstampedLines.size(), results.size());
+        for (int i = 0; i < results.size(); i++) {
+            if (appendLog) {
+                assertTrue(results.get(i).length() >= patternLength);
+            } else {
+                assertEquals(patternLength, results.get(i).length());
+            }
+
+            String timestamp = results.get(i).substring(0, patternLength);
+            assertNotNull(ZonedDateTime.parse(timestamp, DateTimeFormatter.ISO_DATE_TIME));
+
+            if (appendLog) {
+                assertEquals(
+                        String.format("%s  %s", timestamp, unstampedLines.get(i)), results.get(i));
+            }
+        }
+    }
+
+    private static void elapsed(
+            Run<?, ?> build,
+            List<String> unstampedLines,
+            String pattern,
+            int patternLength,
+            boolean appendLog)
+            throws IOException {
+        List<String> results =
+                getQueryResults(
+                        build,
+                        String.format("elapsed=%s%s", pattern, appendLog ? "&appendLog" : ""));
+        assertEquals(unstampedLines.size(), results.size());
+        for (int i = 0; i < results.size(); i++) {
+            if (appendLog) {
+                assertTrue(results.get(i).length() >= patternLength);
+            } else {
+                assertEquals(patternLength, results.get(i).length());
+            }
+
+            String timestamp = results.get(i).substring(0, patternLength);
+            assertNotNull(Duration.parse(timestamp));
+
+            if (appendLog) {
+                assertEquals(
+                        String.format("%s  %s", timestamp, unstampedLines.get(i)), results.get(i));
+            }
+        }
+    }
+
+    private static void currentTime(Run<?, ?> build, String pattern, String timezone)
+            throws IOException {
+        List<String> results =
+                getQueryResults(
+                        build, String.format("currentTime&time=%s&timeZone=%s", pattern, timezone));
+        assertEquals(1, results.size());
+        assertNotNull(ZonedDateTime.parse(results.get(0), DateTimeFormatter.ISO_DATE_TIME));
+    }
+
+    private static List<String> getQueryResults(Run<?, ?> build, String queryString)
+            throws IOException {
+        TimestampsActionQuery query = TimestampsActionQuery.create(queryString);
+        List<String> result;
+        try (BufferedReader reader = TimestampsActionOutput.open(build, query)) {
+            result = reader.lines().collect(Collectors.toList());
+        }
+        return result;
+    }
+}

--- a/src/test/java/hudson/plugins/timestamper/TimestamperIntegrationTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperIntegrationTest.java
@@ -75,4 +75,15 @@ public class TimestamperIntegrationTest {
 
         return timestamps;
     }
+
+    @Test
+    public void timestamperApi() throws Exception {
+        FreeStyleProject project = r.createFreeStyleProject();
+        project.getBuildersList()
+                .add(Functions.isWindows() ? new BatchFile("echo foo") : new Shell("echo foo"));
+        project.getBuildWrappersList().add(new TimestamperBuildWrapper());
+        FreeStyleBuild build = r.buildAndAssertSuccess(project);
+        r.assertLogContains("foo", build);
+        TimestamperApiTestUtil.timestamperApi(build);
+    }
 }

--- a/src/test/java/hudson/plugins/timestamper/TimestamperIntegrationTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperIntegrationTest.java
@@ -84,6 +84,7 @@ public class TimestamperIntegrationTest {
         project.getBuildWrappersList().add(new TimestamperBuildWrapper());
         FreeStyleBuild build = r.buildAndAssertSuccess(project);
         r.assertLogContains("foo", build);
-        TimestamperApiTestUtil.timestamperApi(build);
+        List<String> unstampedLines = build.getLog(Integer.MAX_VALUE);
+        TimestamperApiTestUtil.timestamperApi(build, unstampedLines);
     }
 }

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -8,6 +8,7 @@ import com.gargoylesoftware.htmlunit.WebClientUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlPreformattedText;
 import com.gargoylesoftware.htmlunit.html.HtmlSpan;
+import hudson.plugins.timestamper.TimestamperApiTestUtil;
 import hudson.plugins.timestamper.TimestamperConfig;
 import java.io.BufferedReader;
 import java.io.StringReader;
@@ -19,6 +20,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -119,6 +121,17 @@ public class PipelineTest {
          * to the annotated console output.
          */
         assertEquals(rawTimestamps, annotatedRawTimestamps);
+    }
+
+    @Ignore
+    @Issue("JENKINS-60007")
+    @Test
+    public void timestamperApi() throws Exception {
+        WorkflowJob project = r.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition("node {\n" + "  echo 'foo'\n" + "}", true));
+        WorkflowRun build = r.buildAndAssertSuccess(project);
+        r.assertLogContains("foo", build);
+        TimestamperApiTestUtil.timestamperApi(build);
     }
 
     private static List<String> getTimestamps(

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -131,7 +131,13 @@ public class PipelineTest {
         project.setDefinition(new CpsFlowDefinition("node {\n" + "  echo 'foo'\n" + "}", true));
         WorkflowRun build = r.buildAndAssertSuccess(project);
         r.assertLogContains("foo", build);
-        TimestamperApiTestUtil.timestamperApi(build);
+        List<String> unstampedLines = new ArrayList<>();
+        for (String line : build.getLog(Integer.MAX_VALUE)) {
+            assertEquals('[', line.charAt(0));
+            assertEquals(']', line.charAt(25));
+            unstampedLines.add(line.substring(27));
+        }
+        TimestamperApiTestUtil.timestamperApi(build, unstampedLines);
     }
 
     private static List<String> getTimestamps(


### PR DESCRIPTION
Inspired by [jenkinsci/timestamper-plugin#25 (comment)](https://github.com/jenkinsci/timestamper-plugin/pull/25#issuecomment-465127035). Adds integration tests for the Timestamper API (also used by the scripting URLs) for both Freestyle jobs and Pipeline jobs. The integration tests currently pass for Freestyle jobs but fail for Pipeline jobs (and are therefore marked with `@Ignore`) due to the regression introduced in jenkinsci/timestamper-plugin#25.

I ran the integration tests for this plugin with JaCoCo and saw that this PR brings integration test coverage for this plugin up to 52% (from 34%).