### PR TITLE
Update plugin POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
@@ -5,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>3.56</version>
     <relativePath />
   </parent>
 
@@ -15,7 +16,7 @@
 
   <name>Timestamper</name>
   <description>Adds timestamps to the Console Output</description>
-  <url>https://github.com/jenkinsci/timestamper-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <licenses>
     <license>
@@ -26,6 +27,10 @@
   </licenses>
 
   <developers>
+    <developer>
+      <id>basil</id>
+      <name>Basil Crow</name>
+    </developer>
     <developer>
       <id>stevengbrown</id>
       <name>Steven Brown</name>
@@ -70,7 +75,6 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.150.3</jenkins.version>
     <java.level>8</java.level>
-    <useBeta>true</useBeta>
   </properties>
 
   <build>


### PR DESCRIPTION
- Bump plugin POM to latest version
- Use `${project.artifactId}` in the GitHub URL for consistency with the archetype
- Add self to developer list
- Remove no-longer-needed `useBeta` property