### PR TITLE
[JENKINS-60007] Timestamper scripting API doesn't work for Pipeline jobs

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/accessor/FreestyleTimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/FreestyleTimestampLogFileLineAccessor.java
@@ -1,0 +1,106 @@
+package hudson.plugins.timestamper.accessor;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.io.CountingInputStream;
+import hudson.console.ConsoleNote;
+import hudson.model.Run;
+import hudson.plugins.timestamper.Timestamp;
+import hudson.plugins.timestamper.TimestampNote;
+import hudson.plugins.timestamper.io.LogFileReader;
+import hudson.plugins.timestamper.io.TimestampsReader;
+import hudson.plugins.timestamper.io.TimestampsWriter;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Optional;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Implementation of {@link TimestampLogFileLineAccessor} for Freestyle jobs. In contrast to
+ * Pipeline jobs, Freestyle jobs do not embed the timestamps in the main log file. Rather, they use
+ * a separate timestamps file in {@link TimestampsWriter}, optionally adding a {@link ConsoleNote}
+ * based on the settings in {@link TimestampNote}.
+ */
+@Restricted(NoExternalUse.class)
+public class FreestyleTimestampLogFileLineAccessor implements TimestampLogFileLineAccessor {
+
+    private final TimestampsReader timestampsReader;
+    private final LogFileReader logFileReader;
+    private final Run<?, ?> build;
+
+    public FreestyleTimestampLogFileLineAccessor(
+            TimestampsReader timestampsReader, LogFileReader logFileReader, Run<?, ?> build) {
+        this.timestampsReader = checkNotNull(timestampsReader);
+        this.logFileReader = checkNotNull(logFileReader);
+        this.build = checkNotNull(build);
+    }
+
+    @Override
+    public LogFileReader getLogFileReader() {
+        return logFileReader;
+    }
+
+    @Override
+    public void skipLine() throws IOException {
+        timestampsReader.read();
+        logFileReader.nextLine();
+    }
+
+    @Override
+    public TimestampLogFileLine readLine() throws IOException {
+        Optional<Timestamp> timestamp = timestampsReader.read();
+        Optional<String> logFileLine = logFileReader.nextLine();
+
+        // This implementation relies primarily on the timestamps embedded in the timstamps file,
+        // falling back to looking for ConsoleNotes only if necessary.
+        if (logFileLine.isPresent() && !timestamp.isPresent()) {
+            timestamp = readTimestamp(logFileLine.get());
+        }
+
+        return new TimestampLogFileLine(timestamp, logFileLine);
+    }
+
+    /**
+     * Read the time-stamp from the {@link ConsoleNote} in this line, if present.
+     *
+     * @return the time-stamp
+     */
+    private Optional<Timestamp> readTimestamp(String line) {
+        byte[] bytes = line.getBytes(build.getCharset());
+        int length = bytes.length;
+
+        int index = 0;
+        while (true) {
+            index = ConsoleNote.findPreamble(bytes, index, length - index);
+            if (index == -1) {
+                return Optional.empty();
+            }
+            CountingInputStream inputStream =
+                    new CountingInputStream(new ByteArrayInputStream(bytes, index, length - index));
+
+            try {
+                ConsoleNote<?> consoleNote = ConsoleNote.readFrom(new DataInputStream(inputStream));
+                if (consoleNote instanceof TimestampNote) {
+                    TimestampNote timestampNote = (TimestampNote) consoleNote;
+                    Timestamp timestamp = timestampNote.getTimestamp(build);
+                    return Optional.of(timestamp);
+                }
+            } catch (IOException e) {
+                // Error reading console note, e.g. end of stream. Ignore.
+            } catch (ClassNotFoundException e) {
+                // Unknown console note. Ignore.
+            }
+
+            // Advance at least one character to avoid an infinite loop.
+            index += Math.max(inputStream.getCount(), 1);
+        }
+    }
+
+    @Override
+    public void close() {
+        timestampsReader.close();
+        logFileReader.close();
+    }
+}

--- a/src/main/java/hudson/plugins/timestamper/accessor/PipelineTimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/PipelineTimestampLogFileLineAccessor.java
@@ -9,6 +9,7 @@ import hudson.plugins.timestamper.pipeline.GlobalAnnotator;
 import hudson.plugins.timestamper.pipeline.GlobalDecorator;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -41,9 +42,9 @@ public class PipelineTimestampLogFileLineAccessor implements TimestampLogFileLin
 
     @Override
     public TimestampLogFileLine readLine() throws IOException {
-        // Singleton arrays for use with the below lambda expression
-        Timestamp[] timestampRef = new Timestamp[1];
-        String[] logFileLineRef = new String[1];
+        // AtomicReference for use with the below lambda expression
+        AtomicReference<Timestamp> timestampRef = new AtomicReference<>();
+        AtomicReference<String> logFileLineRef = new AtomicReference<>();
 
         logFileReader
                 .nextLine()
@@ -53,15 +54,15 @@ public class PipelineTimestampLogFileLineAccessor implements TimestampLogFileLin
                                     GlobalAnnotator.parseTimestamp(
                                             logFileLine, 0, build.getStartTimeInMillis());
                             if (timestamp.isPresent()) {
-                                timestampRef[0] = timestamp.get();
-                                logFileLineRef[0] = logFileLine.substring(27);
+                                timestampRef.set(timestamp.get());
+                                logFileLineRef.set(logFileLine.substring(27));
                             } else {
-                                logFileLineRef[0] = logFileLine;
+                                logFileLineRef.set(logFileLine);
                             }
                         });
 
         return new TimestampLogFileLine(
-                Optional.ofNullable(timestampRef[0]), Optional.ofNullable(logFileLineRef[0]));
+                Optional.ofNullable(timestampRef.get()), Optional.ofNullable(logFileLineRef.get()));
     }
 
     @Override

--- a/src/main/java/hudson/plugins/timestamper/accessor/PipelineTimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/PipelineTimestampLogFileLineAccessor.java
@@ -1,0 +1,71 @@
+package hudson.plugins.timestamper.accessor;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import hudson.model.Run;
+import hudson.plugins.timestamper.Timestamp;
+import hudson.plugins.timestamper.io.LogFileReader;
+import hudson.plugins.timestamper.pipeline.GlobalAnnotator;
+import hudson.plugins.timestamper.pipeline.GlobalDecorator;
+import java.io.IOException;
+import java.util.Optional;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Implementation of {@link TimestampLogFileLineAccessor} for Pipeline jobs. In contrast to
+ * Freestyle jobs, Pipeline jobs do not use a separate timestamps file. Rather, timestamps are
+ * embedded into the main log file in {@link GlobalDecorator} and annotated dynamically when the
+ * console log is viewed in {@link GlobalAnnotator}.
+ */
+@Restricted(NoExternalUse.class)
+public class PipelineTimestampLogFileLineAccessor implements TimestampLogFileLineAccessor {
+
+    private final LogFileReader logFileReader;
+    private final Run<?, ?> build;
+
+    public PipelineTimestampLogFileLineAccessor(LogFileReader logFileReader, Run<?, ?> build) {
+        this.logFileReader = checkNotNull(logFileReader);
+        this.build = checkNotNull(build);
+    }
+
+    @Override
+    public LogFileReader getLogFileReader() {
+        return logFileReader;
+    }
+
+    @Override
+    public void skipLine() throws IOException {
+        logFileReader.nextLine();
+    }
+
+    @Override
+    public TimestampLogFileLine readLine() throws IOException {
+        // Singleton arrays for use with the below lambda expression
+        Timestamp[] timestampRef = new Timestamp[1];
+        String[] logFileLineRef = new String[1];
+
+        logFileReader
+                .nextLine()
+                .ifPresent(
+                        logFileLine -> {
+                            Optional<Timestamp> timestamp =
+                                    GlobalAnnotator.parseTimestamp(
+                                            logFileLine, 0, build.getStartTimeInMillis());
+                            if (timestamp.isPresent()) {
+                                timestampRef[0] = timestamp.get();
+                                logFileLineRef[0] = logFileLine.substring(27);
+                            } else {
+                                logFileLineRef[0] = logFileLine;
+                            }
+                        });
+
+        return new TimestampLogFileLine(
+                Optional.ofNullable(timestampRef[0]), Optional.ofNullable(logFileLineRef[0]));
+    }
+
+    @Override
+    public void close() {
+        logFileReader.close();
+    }
+}

--- a/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
@@ -49,7 +49,7 @@ public interface TimestampLogFileLineAccessor extends Closeable {
     }
 
     /**
-     * Retrieve the {@link LogFileReader} associated with this accessor, likely for use with {@link
+     * Retrieve the {@link LogFileReader} associated with this accessor, likely for use with {@code
      * TimestampsActionOutput.LineCountSupplier}.
      */
     LogFileReader getLogFileReader();

--- a/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
@@ -1,0 +1,67 @@
+package hudson.plugins.timestamper.accessor;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import hudson.plugins.timestamper.Timestamp;
+import hudson.plugins.timestamper.action.TimestampsActionOutput;
+import hudson.plugins.timestamper.io.LogFileReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Optional;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Abstraction for retrieving timestamps and log file lines from completed builds. Timestamp records
+ * can be stored in different files and formats for different types of builds. Consumers that wish
+ * to retrieve such records should use this interface rather than directly opening the corresponding
+ * log file.
+ */
+@Restricted(NoExternalUse.class)
+public interface TimestampLogFileLineAccessor extends Closeable {
+
+    /**
+     * Value class representing a single record in the abstract, regardless of how the storage of
+     * that record is implemented.
+     */
+    class TimestampLogFileLine {
+        private final Optional<Timestamp> timestamp;
+        private final Optional<String> logFileLine;
+
+        public TimestampLogFileLine(Optional<Timestamp> timestamp, Optional<String> logFileLine) {
+            this.timestamp = checkNotNull(timestamp);
+            this.logFileLine = checkNotNull(logFileLine);
+        }
+
+        /** Return the timestamp associated with the record, if present. */
+        public Optional<Timestamp> getTimestamp() {
+            return timestamp;
+        }
+
+        /**
+         * Return the log file line associated with the record, if present. This log file line may
+         * contain console notes. It is the caller's responsibility to remove any console notes if
+         * desired.
+         */
+        public Optional<String> getLogFileLine() {
+            return logFileLine;
+        }
+    }
+
+    /**
+     * Retrieve the {@link LogFileReader} associated with this accessor, likely for use with {@link
+     * TimestampsActionOutput.LineCountSupplier}.
+     */
+    LogFileReader getLogFileReader();
+
+    /** Skip forward one line in the associated record file(s). */
+    void skipLine() throws IOException;
+
+    /**
+     * Retrieve a log file line and its associated timestamp. While typically both a timestamp and a
+     * log file line will be present, this API is resilient to edge cases in which one or the other
+     * is not present. When neither a timestamp nor a log file line are present, EOF has been
+     * reached and callers should stop retrieving further records.
+     */
+    TimestampLogFileLine readLine() throws IOException;
+}

--- a/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
@@ -3,7 +3,6 @@ package hudson.plugins.timestamper.accessor;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import hudson.plugins.timestamper.Timestamp;
-import hudson.plugins.timestamper.action.TimestampsActionOutput;
 import hudson.plugins.timestamper.io.LogFileReader;
 import java.io.Closeable;
 import java.io.IOException;
@@ -60,8 +59,9 @@ public interface TimestampLogFileLineAccessor extends Closeable {
     /**
      * Retrieve a log file line and its associated timestamp. While typically both a timestamp and a
      * log file line will be present, this API is resilient to edge cases in which one or the other
-     * is not present. When neither a timestamp nor a log file line are present, EOF has been
-     * reached and callers should stop retrieving further records.
+     * is not present. In such cases, consumers have a choice as to whether to discard the record or
+     * return incomplete information to the user. When neither a timestamp nor a log file line are
+     * present, EOF has been reached and callers should stop retrieving further records.
      */
     TimestampLogFileLine readLine() throws IOException;
 }

--- a/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
@@ -24,7 +24,7 @@ public interface TimestampLogFileLineAccessor extends Closeable {
      * Value class representing a single record in the abstract, regardless of how the storage of
      * that record is implemented.
      */
-    class TimestampLogFileLine {
+    final class TimestampLogFileLine {
         private final Optional<Timestamp> timestamp;
         private final Optional<String> logFileLine;
 

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -20,7 +20,6 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -123,7 +122,6 @@ public class PipelineTest {
         assertEquals(rawTimestamps, annotatedRawTimestamps);
     }
 
-    @Ignore
     @Issue("JENKINS-60007")
     @Test
     public void timestamperApi() throws Exception {


### PR DESCRIPTION
See [JENKINS-60007](https://issues.jenkins-ci.org/browse/JENKINS-60007) and [#25 (comment)](https://github.com/jenkinsci/timestamper-plugin/pull/25#issuecomment-465127035). This PR gets the tests added in #44 working for Pipeline jobs by making the necessary adjustments for the existing functionality to work with the new architecture added in #25.

The way I went about this was by extracting all existing Freestyle-specific functionality from the existing `TimestampsActionOutput` and `LogFileReader` classes into a new `FreestyleTimestampLogFileLineAccessor` class. I did not modify any of this existing logic out of concern for possibly introducing any regressions. I then generalized a new `TimestampLogFileLineAccessor` interface out of the existing Freestyle implementation and made `FreestyleTimestampLogFileLineAccessor` implement this new interface. Finally, I added a new `PipelineTimestampLogFileLineAccessor` implementation of this interface that works with the new architecture.

Some implementation notes that might be helpful for reviewers:

- The existing `LogFileReader.Line#readTimestamp` method only seemed relevant for Freestyle jobs, since it relied on a `ConsoleNote` being present in the log line, and this type of `ConsoleNote` is no longer present in the new Pipeline architecture. Therefore, I moved this method to `FreestyleTimestampLogFileLineAccessor`. This necessitated a slight change of semantics for `LogFileReader`, which previously stripped all console notes. Now it could no longer do so, since they would be needed later on by `FreestyleTimestampLogFileLineAccessor`. I updated the Javadocs to explain the change of semantics and updated any callers to strip console notes at the `TimestampLogFileLineAccessor` caller layer rather than at the `LogFileReader` layer. Once this was done, `LogFileReader.Line` became dead code, which I then deleted.
- The logic to parse timestamps from the new architecture already existed in `GlobalAnnotator`, but I needed it from the new `PipelineTimestampLogFileLineAccessor` class as well. I generalized the existing logic into a `GlobalAnnotator#parseTimestamp` method so that I could call it from both places.