### PR TITLE
Correctly deal with TimestampNote

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/TimestampNote.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestampNote.java
@@ -39,11 +39,14 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * <p>These are inserted into the log file when:
  *
  * <ul>
- *   <li>Running a pipeline build or any other build which does not extend {@link AbstractBuild} OR
- *   <li>Running the Timestamper plugin prior to version 1.4 OR
- *   <li>The system property is set: ({@link #getSystemProperty()}). The is intended to support
- *       scripts that were written prior to Timestamper 1.4 to parse the log files. New scripts
- *       should query the {@code /timestamps} URL instead (see {@link TimestampsAction}).
+ *   <li>Running a Pipeline build or any other build which does not extend {@link AbstractBuild}
+ *       prior to version 1.9 OR
+ *   <li>Running a Freestyle build or any other build which extends {@link AbstractBuild} prior to
+ *       version 1.4 OR
+ *   <li>Running a Freestyle build or any other build which extends {@link AbstractBuild} and the
+ *       system property is set: ({@link #getSystemProperty()}). This is intended to support scripts
+ *       that were written prior to version 1.4 to parse the log files. New scripts should query the
+ *       {@code /timestamps} URL instead (see {@link TimestampsAction}).
  * </ul>
  *
  * <p>Otherwise, the time-stamps are stored in a separate file, which allows a more compact format

--- a/src/main/java/hudson/plugins/timestamper/accessor/FreestyleTimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/FreestyleTimestampLogFileLineAccessor.java
@@ -2,16 +2,11 @@ package hudson.plugins.timestamper.accessor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.io.CountingInputStream;
-import hudson.console.ConsoleNote;
 import hudson.model.Run;
 import hudson.plugins.timestamper.Timestamp;
-import hudson.plugins.timestamper.TimestampNote;
 import hudson.plugins.timestamper.io.LogFileReader;
 import hudson.plugins.timestamper.io.TimestampsReader;
 import hudson.plugins.timestamper.io.TimestampsWriter;
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Optional;
 import org.kohsuke.accmod.Restricted;
@@ -20,8 +15,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 /**
  * Implementation of {@link TimestampLogFileLineAccessor} for Freestyle jobs. In contrast to
  * Pipeline jobs, Freestyle jobs do not embed the timestamps in the main log file. Rather, they use
- * a separate timestamps file in {@link TimestampsWriter}, optionally adding a {@link ConsoleNote}
- * based on the settings in {@link TimestampNote}.
+ * a separate timestamps file in {@link TimestampsWriter}.
  */
 @Restricted(NoExternalUse.class)
 public class FreestyleTimestampLogFileLineAccessor implements TimestampLogFileLineAccessor {
@@ -52,50 +46,7 @@ public class FreestyleTimestampLogFileLineAccessor implements TimestampLogFileLi
     public TimestampLogFileLine readLine() throws IOException {
         Optional<Timestamp> timestamp = timestampsReader.read();
         Optional<String> logFileLine = logFileReader.nextLine();
-
-        // This implementation relies primarily on the timestamps embedded in the timstamps file,
-        // falling back to looking for ConsoleNotes only if necessary.
-        if (logFileLine.isPresent() && !timestamp.isPresent()) {
-            timestamp = readTimestamp(logFileLine.get());
-        }
-
         return new TimestampLogFileLine(timestamp, logFileLine);
-    }
-
-    /**
-     * Read the time-stamp from the {@link ConsoleNote} in this line, if present.
-     *
-     * @return the time-stamp
-     */
-    private Optional<Timestamp> readTimestamp(String line) {
-        byte[] bytes = line.getBytes(build.getCharset());
-        int length = bytes.length;
-
-        int index = 0;
-        while (true) {
-            index = ConsoleNote.findPreamble(bytes, index, length - index);
-            if (index == -1) {
-                return Optional.empty();
-            }
-            CountingInputStream inputStream =
-                    new CountingInputStream(new ByteArrayInputStream(bytes, index, length - index));
-
-            try {
-                ConsoleNote<?> consoleNote = ConsoleNote.readFrom(new DataInputStream(inputStream));
-                if (consoleNote instanceof TimestampNote) {
-                    TimestampNote timestampNote = (TimestampNote) consoleNote;
-                    Timestamp timestamp = timestampNote.getTimestamp(build);
-                    return Optional.of(timestamp);
-                }
-            } catch (IOException e) {
-                // Error reading console note, e.g. end of stream. Ignore.
-            } catch (ClassNotFoundException e) {
-                // Unknown console note. Ignore.
-            }
-
-            // Advance at least one character to avoid an infinite loop.
-            index += Math.max(inputStream.getCount(), 1);
-        }
     }
 
     @Override

--- a/src/main/java/hudson/plugins/timestamper/accessor/PipelineTimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/PipelineTimestampLogFileLineAccessor.java
@@ -2,11 +2,16 @@ package hudson.plugins.timestamper.accessor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.io.CountingInputStream;
+import hudson.console.ConsoleNote;
 import hudson.model.Run;
 import hudson.plugins.timestamper.Timestamp;
+import hudson.plugins.timestamper.TimestampNote;
 import hudson.plugins.timestamper.io.LogFileReader;
 import hudson.plugins.timestamper.pipeline.GlobalAnnotator;
 import hudson.plugins.timestamper.pipeline.GlobalDecorator;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -14,10 +19,12 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
- * Implementation of {@link TimestampLogFileLineAccessor} for Pipeline jobs. In contrast to
- * Freestyle jobs, Pipeline jobs do not use a separate timestamps file. Rather, timestamps are
- * embedded into the main log file in {@link GlobalDecorator} and annotated dynamically when the
- * console log is viewed in {@link GlobalAnnotator}.
+ * Implementation of {@link TimestampLogFileLineAccessor} for Pipeline jobs as well as Freestyle
+ * jobs that were annotated with the "timestamper-consolenotes" property set (or Freestyle jobs
+ * prior to version 1.4 of this plugin). In contrast to Freestyle jobs, Pipeline jobs do not use a
+ * separate timestamps file. Rather, timestamps are embedded into the main log file in {@link
+ * GlobalDecorator} and annotated dynamically when the console log is viewed in {@link
+ * GlobalAnnotator}.
  */
 @Restricted(NoExternalUse.class)
 public class PipelineTimestampLogFileLineAccessor implements TimestampLogFileLineAccessor {
@@ -57,12 +64,53 @@ public class PipelineTimestampLogFileLineAccessor implements TimestampLogFileLin
                                 timestampRef.set(timestamp.get());
                                 logFileLineRef.set(logFileLine.substring(27));
                             } else {
+                                // Pipeline jobs prior to version 1.9 of this plugin (as well as
+                                // Freestyle jobs prior to version 1.4 of this plugin, or when the
+                                // "timestamper-consolenotes" system property was enabled) used
+                                // TimestampNote rather than GlobalDecorator.
+                                readTimestamp(logFileLine).ifPresent(timestampRef::set);
                                 logFileLineRef.set(logFileLine);
                             }
                         });
 
         return new TimestampLogFileLine(
                 Optional.ofNullable(timestampRef.get()), Optional.ofNullable(logFileLineRef.get()));
+    }
+
+    /**
+     * Read the time-stamp from the {@link ConsoleNote} in this line, if present.
+     *
+     * @return the time-stamp
+     */
+    private Optional<Timestamp> readTimestamp(String line) {
+        byte[] bytes = line.getBytes(build.getCharset());
+        int length = bytes.length;
+
+        int index = 0;
+        while (true) {
+            index = ConsoleNote.findPreamble(bytes, index, length - index);
+            if (index == -1) {
+                return Optional.empty();
+            }
+            CountingInputStream inputStream =
+                    new CountingInputStream(new ByteArrayInputStream(bytes, index, length - index));
+
+            try {
+                ConsoleNote<?> consoleNote = ConsoleNote.readFrom(new DataInputStream(inputStream));
+                if (consoleNote instanceof TimestampNote) {
+                    TimestampNote timestampNote = (TimestampNote) consoleNote;
+                    Timestamp timestamp = timestampNote.getTimestamp(build);
+                    return Optional.of(timestamp);
+                }
+            } catch (IOException e) {
+                // Error reading console note, e.g. end of stream. Ignore.
+            } catch (ClassNotFoundException e) {
+                // Unknown console note. Ignore.
+            }
+
+            // Advance at least one character to avoid an infinite loop.
+            index += Math.max(inputStream.getCount(), 1);
+        }
     }
 
     @Override


### PR DESCRIPTION
Found a bug in #47 related to the `TimestampNote` parsing functionality in `readTimestamp`. What really helped me understand things was doing some testing of Pipeline jobs in Timestamper 1.8. I saw that there, `TimestampNotes` were added and no timestamps file was created. I was able to reproduce this behavior on `master` with Freestyle jobs by setting the `timestamper-consolenotes` system property.

Based on this discovery, I realized that I had placed the `TimestampNote` parsing functionality in the wrong place in #47. It doesn't belong in `FreestyleTimestampLogFileLineAccessor` because that is only used when a timestamps file exists, and when a timestamps file is used then `TimestampNote` is not used. Rather this logic belongs in `PipelineTimestampLogFileLineAccessor`, which is used when a timestamps file does not exist.

Now in `PipelineTimestampLogFileLineAccessor` the common case is for the timestamps to come from `GlobalDecorator`. But there are two corner cases where `TimestampNote`s can be present: a Pipeline build done with a version of Timestamper prior to 1.9, or a Freestyle build with the `timestamper-consolenotes` system property set. Fortunately I was able to write a test for the latter, which fails prior to this change and passes with this change (and exercises the  `readTimestamp` method).

I also updated the Javadocs and code comments to properly explain things.