### PR TITLE
Update JUnit to 4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,12 @@
       <version>2.22</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/src/test/java/hudson/plugins/timestamper/TimestampNoteTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestampNoteTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/hudson/plugins/timestamper/TimestampNotesOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestampNotesOutputStreamTest.java
@@ -23,10 +23,10 @@
  */
 package hudson.plugins.timestamper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.primitives.Bytes;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/hudson/plugins/timestamper/TimestampTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestampTest.java
@@ -24,7 +24,7 @@
 package hudson.plugins.timestamper;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import nl.jqno.equalsverifier.EqualsVerifier;

--- a/src/test/java/hudson/plugins/timestamper/TimestamperBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperBuildWrapperTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/hudson/plugins/timestamper/TimestamperConfigTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperConfigTest.java
@@ -23,9 +23,9 @@
  */
 package hudson.plugins.timestamper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import hudson.util.XStream2;
 import java.util.Arrays;

--- a/src/test/java/hudson/plugins/timestamper/action/PrecisionTimestampFormatTest.java
+++ b/src/test/java/hudson/plugins/timestamper/action/PrecisionTimestampFormatTest.java
@@ -24,8 +24,8 @@
 package hudson.plugins.timestamper.action;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import hudson.plugins.timestamper.Timestamp;

--- a/src/test/java/hudson/plugins/timestamper/action/TimestampsActionOutputTest.java
+++ b/src/test/java/hudson/plugins/timestamper/action/TimestampsActionOutputTest.java
@@ -23,9 +23,9 @@
  */
 package hudson.plugins.timestamper.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/hudson/plugins/timestamper/action/TimestampsActionQueryTest.java
+++ b/src/test/java/hudson/plugins/timestamper/action/TimestampsActionQueryTest.java
@@ -23,8 +23,9 @@
  */
 package hudson.plugins.timestamper.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
@@ -44,9 +45,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -307,17 +306,16 @@ public class TimestampsActionQueryTest {
   @Parameter(1)
   public Object expectedResult;
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
   @Test
   public void testCreate() {
     if (expectedResult instanceof Class<?>) {
       @SuppressWarnings("unchecked")
       Class<? extends Throwable> expectedThrowable = (Class<? extends Throwable>) expectedResult;
-      thrown.expect(expectedThrowable);
+      assertThrows(expectedThrowable, () -> TimestampsActionQuery.create(queryString));
+    } else {
+      TimestampsActionQuery query = TimestampsActionQuery.create(queryString);
+      assertThat(query, is(expectedResult));
     }
-    TimestampsActionQuery query = TimestampsActionQuery.create(queryString);
-    assertThat(query, is(expectedResult));
   }
 
   @Test

--- a/src/test/java/hudson/plugins/timestamper/annotator/ConsoleLogParserTest.java
+++ b/src/test/java/hudson/plugins/timestamper/annotator/ConsoleLogParserTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.annotator;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/timestamper/annotator/TimestampAnnotatorTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.annotator;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/hudson/plugins/timestamper/format/ElapsedTimestampFormatTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/ElapsedTimestampFormatTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.format;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import hudson.plugins.timestamper.Timestamp;
 import nl.jqno.equalsverifier.EqualsVerifier;

--- a/src/test/java/hudson/plugins/timestamper/format/EmptyTimestampFormatTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/EmptyTimestampFormatTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.format;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import hudson.plugins.timestamper.Timestamp;
 import org.junit.Test;

--- a/src/test/java/hudson/plugins/timestamper/format/FormatStringUtilsTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/FormatStringUtilsTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.format;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/hudson/plugins/timestamper/format/SystemTimestampFormatTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/SystemTimestampFormatTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.format;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import hudson.plugins.timestamper.Timestamp;
 import java.util.Locale;

--- a/src/test/java/hudson/plugins/timestamper/format/TimeZoneUtilsTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/TimeZoneUtilsTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.format;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/hudson/plugins/timestamper/format/TimestampFormatProviderTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/TimestampFormatProviderTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.format;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/hudson/plugins/timestamper/format/TimestampFormatTest.java
+++ b/src/test/java/hudson/plugins/timestamper/format/TimestampFormatTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.format;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import hudson.MarkupText;

--- a/src/test/java/hudson/plugins/timestamper/io/LogFileReaderTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/LogFileReaderTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.io;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/hudson/plugins/timestamper/io/TimestampsIOTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/TimestampsIOTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.io;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/hudson/plugins/timestamper/io/TimestampsReaderTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/TimestampsReaderTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.io;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/hudson/plugins/timestamper/io/TimestampsWriterTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/TimestampsWriterTest.java
@@ -23,11 +23,12 @@
  */
 package hudson.plugins.timestamper.io;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,7 +49,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.powermock.reflect.Whitebox;
 
@@ -60,8 +60,6 @@ import org.powermock.reflect.Whitebox;
 public class TimestampsWriterTest {
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   private Run<?, ?> build;
 
@@ -163,8 +161,7 @@ public class TimestampsWriterTest {
   @Test
   public void testOnlyOneWriterPerBuild() throws Exception {
     timestampsWriter = new TimestampsWriter(build);
-    thrown.expect(IOException.class);
-    timestampsWriter = new TimestampsWriter(build);
+    assertThrows(IOException.class, () -> timestampsWriter = new TimestampsWriter(build));
   }
 
   private List<Integer> writtenTimestampData() throws Exception {

--- a/src/test/java/hudson/plugins/timestamper/io/VarintTest.java
+++ b/src/test/java/hudson/plugins/timestamper/io/VarintTest.java
@@ -23,8 +23,8 @@
  */
 package hudson.plugins.timestamper.io;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import com.google.common.primitives.Bytes;
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
Updates JUnit from 4.12 to 4.13 and adapts any usages of deprecated methods to their non-deprecated equivalents.