### PR TITLE
Add additional test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.56</version>
+    <version>3.57</version>
     <relativePath />
   </parent>
 
@@ -183,12 +183,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
       <version>2.22</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/hudson/plugins/timestamper/TimestamperApiTestUtil.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperApiTestUtil.java
@@ -5,8 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import hudson.model.Run;
-import hudson.plugins.timestamper.action.TimestampsActionOutput;
-import hudson.plugins.timestamper.action.TimestampsActionQuery;
+import hudson.plugins.timestamper.api.TimestamperAPI;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.time.Duration;
@@ -100,9 +99,8 @@ public class TimestamperApiTestUtil {
 
     private static List<String> getQueryResults(Run<?, ?> build, String queryString)
             throws IOException {
-        TimestampsActionQuery query = TimestampsActionQuery.create(queryString);
         List<String> result;
-        try (BufferedReader reader = TimestampsActionOutput.open(build, query)) {
+        try (BufferedReader reader = TimestamperAPI.get().read(build, queryString)) {
             result = reader.lines().collect(Collectors.toList());
         }
         return result;


### PR DESCRIPTION
Increases integration test coverage by exercising `TimestamperAPI` in `TimestamperApiTestUtil` and by exercising `TimestamperStep` in `PipelineTest`. I also improved `PipelineTest#timestamperApi` to take advantage of the new `GlobalAnnotator.parseTimestamp` method introduced in #47, which improved a test assertion. Between this and #48, integration test coverage is now up to 60% in JaCoCo.

As a bonus, I updated the plugin POM, which pulled in JUnit 4.13 and allowed me to remove the explicit JUnit version set in #49 (which will be helpful when I enable Dependabot for this repository).