### PR TITLE
Add tests for startLine and endLine

### DIFF
--- a/src/test/java/hudson/plugins/timestamper/TimestamperApiTestUtil.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperApiTestUtil.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.DiscreteDomains;
+import com.google.common.collect.Ranges;
 import hudson.model.Run;
 import hudson.plugins.timestamper.api.TimestamperAPI;
 import java.io.BufferedReader;
@@ -18,11 +20,31 @@ public class TimestamperApiTestUtil {
 
     public static void timestamperApi(Run<?, ?> build, List<String> unstampedLines)
             throws IOException {
-        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", false);
-        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", true);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 0, 0, false);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 3, 0, false);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", -4, 0, false);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 0, 4, false);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 0, -3, false);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 2, 5, false);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 0, 0, true);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 3, 0, true);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", -4, 0, true);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 0, 4, true);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 0, -3, true);
+        time(build, unstampedLines, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", 24, "UTC", 2, 5, true);
 
-        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, false);
-        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, true);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 0, 0, false);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 3, 0, false);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, -4, 0, false);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 0, 4, false);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 0, -3, false);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 2, 5, false);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 0, 0, true);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 3, 0, true);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, -4, 0, true);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 0, 4, true);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 0, -3, true);
+        elapsed(build, unstampedLines, "'P'd'DT'H'H'm'M's.S'S'", 14, 2, 5, true);
 
         currentTime(build, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "UTC");
     }
@@ -33,15 +55,39 @@ public class TimestamperApiTestUtil {
             String pattern,
             int patternLength,
             String timezone,
+            int startLine,
+            int endLine,
             boolean appendLog)
             throws IOException {
         List<String> results =
                 getQueryResults(
                         build,
                         String.format(
-                                "time=%s&timeZone=%s%s",
-                                pattern, timezone, appendLog ? "&appendLog" : ""));
-        assertEquals(unstampedLines.size(), results.size());
+                                "time=%s&timeZone=%s%s%s%s",
+                                pattern,
+                                timezone,
+                                startLine != 0 ? String.format("&startLine=%s", startLine) : "",
+                                endLine != 0 ? String.format("&endLine=%s", endLine) : "",
+                                appendLog ? "&appendLog" : ""));
+        int lower;
+        if (startLine < 0) {
+            lower = unstampedLines.size() + startLine + 1;
+        } else if (startLine > 0) {
+            lower = startLine;
+        } else {
+            lower = 1;
+        }
+        int upper;
+        if (endLine < 0) {
+            upper = unstampedLines.size() + endLine + 1;
+        } else if (endLine > 0) {
+            upper = endLine;
+        } else {
+            upper = unstampedLines.size();
+        }
+        assertEquals(
+                Ranges.closed(lower, upper).asSet(DiscreteDomains.integers()).size(),
+                results.size());
         for (int i = 0; i < results.size(); i++) {
             if (appendLog) {
                 assertTrue(results.get(i).length() >= patternLength);
@@ -54,7 +100,11 @@ public class TimestamperApiTestUtil {
 
             if (appendLog) {
                 assertEquals(
-                        String.format("%s  %s", timestamp, unstampedLines.get(i)), results.get(i));
+                        String.format(
+                                "%s  %s",
+                                timestamp,
+                                unstampedLines.get(i + lower - 1)),
+                        results.get(i));
             }
         }
     }
@@ -64,13 +114,38 @@ public class TimestamperApiTestUtil {
             List<String> unstampedLines,
             String pattern,
             int patternLength,
+            int startLine,
+            int endLine,
             boolean appendLog)
             throws IOException {
         List<String> results =
                 getQueryResults(
                         build,
-                        String.format("elapsed=%s%s", pattern, appendLog ? "&appendLog" : ""));
-        assertEquals(unstampedLines.size(), results.size());
+                        String.format(
+                                "elapsed=%s%s%s%s",
+                                pattern,
+                                startLine != 0 ? String.format("&startLine=%s", startLine) : "",
+                                endLine != 0 ? String.format("&endLine=%s", endLine) : "",
+                                appendLog ? "&appendLog" : ""));
+        int lower;
+        if (startLine < 0) {
+            lower = unstampedLines.size() + startLine + 1;
+        } else if (startLine > 0) {
+            lower = startLine;
+        } else {
+            lower = 1;
+        }
+        int upper;
+        if (endLine < 0) {
+            upper = unstampedLines.size() + endLine + 1;
+        } else if (endLine > 0) {
+            upper = endLine;
+        } else {
+            upper = unstampedLines.size();
+        }
+        assertEquals(
+                Ranges.closed(lower, upper).asSet(DiscreteDomains.integers()).size(),
+                results.size());
         for (int i = 0; i < results.size(); i++) {
             if (appendLog) {
                 assertTrue(results.get(i).length() >= patternLength);
@@ -83,7 +158,11 @@ public class TimestamperApiTestUtil {
 
             if (appendLog) {
                 assertEquals(
-                        String.format("%s  %s", timestamp, unstampedLines.get(i)), results.get(i));
+                        String.format(
+                                "%s  %s",
+                                timestamp,
+                                unstampedLines.get(i + lower - 1)),
+                        results.get(i));
             }
         }
     }

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -27,6 +27,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 public class PipelineTest {
 
+    @Rule public JenkinsRule r = new JenkinsRule();
+
     @Before
     public void setAllPipelines() {
         TimestamperConfig config = TimestamperConfig.get();
@@ -34,10 +36,8 @@ public class PipelineTest {
         config.save();
     }
 
-    @Rule public JenkinsRule r = new JenkinsRule();
-
-    @Test
     @Issue("JENKINS-58102")
+    @Test
     public void globalDecoratorAnnotator() throws Exception {
         WorkflowJob project = r.createProject(WorkflowJob.class);
         project.setDefinition(
@@ -123,6 +123,18 @@ public class PipelineTest {
         assertEquals(rawTimestamps, annotatedRawTimestamps);
     }
 
+    private static List<String> getTimestamps(
+            HtmlPreformattedText consoleOutput, String xpathExpr) {
+        List<String> timestamps = new ArrayList<>();
+
+        List<HtmlSpan> nodes = consoleOutput.getByXPath(xpathExpr);
+        for (HtmlSpan node : nodes) {
+            timestamps.add(node.getTextContent());
+        }
+
+        return timestamps;
+    }
+
     @Issue("JENKINS-60007")
     @Test
     public void timestamperApi() throws Exception {
@@ -158,17 +170,5 @@ public class PipelineTest {
                     GlobalAnnotator.parseTimestamp(line, 0, build.getStartTimeInMillis())
                             .isPresent());
         }
-    }
-
-    private static List<String> getTimestamps(
-            HtmlPreformattedText consoleOutput, String xpathExpr) {
-        List<String> timestamps = new ArrayList<>();
-
-        List<HtmlSpan> nodes = consoleOutput.getByXPath(xpathExpr);
-        for (HtmlSpan node : nodes) {
-            timestamps.add(node.getTextContent());
-        }
-
-        return timestamps;
     }
 }


### PR DESCRIPTION
Brings integration test coverage up to 62%, including full coverage of `TimestampsActionOutput`. After this goes in, I can start to implement JENKINS-54128 without worrying about introducing regressions.