### PR TITLE
Use Mockito and PowerMock versions from plugin POM

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+version: 1
+update_configs:
+- package_manager: "java:maven"
+  directory: "/"
+  update_schedule: "daily"
+  default_reviewers:
+    - "basil"
+  ignored_updates:
+    - match:
+        dependency_name: "org.jenkins-ci.main:jenkins-core"
+    - match:
+        dependency_name: "org.jenkins-ci:symbol-annotation"
+    - match:
+        dependency_name: "org.jenkins-ci.plugins*"
+    - match:
+        dependency_name: "io.jenkins.plugins*"

--- a/pom.xml
+++ b/pom.xml
@@ -139,14 +139,17 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-reflect</artifactId>
-      <version>1.7.4</version>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Use Mockito and PowerMock versions from the plugin POM rather than having to maintain a separate set of versions in this POM. Also add a Dependabot configuration to this repository.