### PR TITLE
Copyedit README; update Javadoc API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Jenkins Timestamper Plugin
+# Timestamper Plugin
 
-[![Jenkins Plugins](https://img.shields.io/jenkins/plugin/v/timestamper)](https://plugins.jenkins.io/timestamper)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/timestamper-plugin/master)](https://ci.jenkins.io/job/Plugins/job/timestamper-plugin/job/master/)
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/timestamper)](https://plugins.jenkins.io/timestamper/)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/timestamper)](https://plugins.jenkins.io/timestamper/)
 
-The Timestamper Plugin adds timestamps to the Console Output of Jenkins jobs.
-
-**Example output:**
+The Timestamper plugin adds timestamps to the console output of Jenkins jobs. For example:
 
 ```
 21:51:15  Started by user anonymous
@@ -12,23 +12,25 @@ The Timestamper Plugin adds timestamps to the Console Output of Jenkins jobs.
 21:51:17  Finished: SUCCESS
 ```
 
-### Instructions: Freestyle
+## Usage
 
-Enable timestamps within the "Build Environment" section of the build's configuration page.
+### Freestyle jobs
 
-To enable timestamps for multiple builds at once, use the [Configuration Slicing Plugin](https://wiki.jenkins.io/display/JENKINS/Configuration+Slicing+Plugin) version 1.32 or later.
+Enable timestamps within the **Build Environment** section of the build’s configuration page.
 
-### Instructions: [Pipeline Builds](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin)
+To enable timestamps for multiple builds at once, use the [Configuration Slicing plugin](https://plugins.jenkins.io/configurationslicing/) version 1.32 or later.
 
-**Since Timestamper 1.9**
+### [Pipeline](https://jenkins.io/doc/book/pipeline/) jobs
 
-Set the global option to enable timestamps for all Pipeline builds (in _**Manage Jenkins**_ → _**Configure**_), or use the step as described below.
+#### Since Timestamper 1.9
+
+Set the global option to enable timestamps for all Pipeline builds (in **Manage Jenkins** → **Configure System**), or use the `timestamps` step as described below.
 
 ![](docs/images/allBuilds.png)
 
-**Since Timestamper 1.8**
+#### Since Timestamper 1.8
 
-Use the `timestamps` step to wrap the rest of the pipeline script.
+Use the `timestamps` step to wrap the rest of the Pipeline script.
 
 ```groovy
 timestamps {
@@ -36,7 +38,7 @@ timestamps {
 }
 ```
 
-**Since Timestamper 1.7**
+#### Since Timestamper 1.7
 
 Prior to Timestamper 1.8, timestamps can only be recorded within a node.
 
@@ -48,17 +50,15 @@ node  {
 }
 ```
 
-### Customization
+## Customization
 
--   The timestamp format can be configured via the `Configure System` page.
+-   The timestamp format can be configured via the **Configure System** page.
 -   There is a panel on the left-hand side of the console page which allows either the system clock time or the elapsed time to be displayed.
--   The time zone used to display the timestamps can be configured by setting a system parameter as described here: [Change time zone](https://wiki.jenkins.io/display/JENKINS/Change+time+zone).
+-   The time zone used to display the timestamps can be configured by setting [a system property](https://wiki.jenkins.io/display/JENKINS/Change+time+zone).
 
-### Scripting
+## Scripting
 
-Scripts can read the timestamps from the `/timestamps/` URL of each build.
-
-Examples:
+Scripts can read the timestamps from the `/timestamps/` URL of each build. For example:
 
 -   `/timestamps/`\
     By default, display the elapsed time in seconds with three places after the decimal point.
@@ -73,34 +73,33 @@ Examples:
 
 Supported query parameters:
 
--   **time** (since 1.8)\
-    Display the system clock time. Accepts the [JDK SimpleDateFormat](http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html) format.\
+-   `time` (since 1.8)\
+    Display the system clock time. Accepts the [JDK `SimpleDateFormat`](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) format.\
     The time zone and locale of the Jenkins server will be used, unless they are configured with the `timeZone` and `locale` query parameters.
--   **elapsed** (since 1.8)\
-    Display the elapsed time since the start of the build. Accepts the [commons-lang DurationFormatUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-2.6/org/apache/commons/lang/time/DurationFormatUtils.html) format.
--   **precision** (since 1.3.2)\
+-   `elapsed` (since 1.8)\
+    Display the elapsed time since the start of the build. Accepts the [Commons Lang `DurationFormatUtils`](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/time/DurationFormatUtils.html) format.
+-   `precision` (since 1.3.2)\
     Display the elapsed time in seconds, with a certain number of places after the decimal point. Accepts a number of decimal places or values such as `seconds` and `milliseconds`.
--   **appendLog** (since 1.8)\
+-   `appendLog` (since 1.8)\
     Display the console log line after the timestamp.
--   **startLine** (since 1.8)\
+-   `startLine` (since 1.8)\
     Display the timestamps starting from a certain line. Accepts a positive integer to start at that line, or a negative integer to start that many lines back from the end.
--   **endLine** (since 1.8)\
+-   `endLine` (since 1.8)\
     Display the timestamps ending at a certain line. Accepts a positive integer to finish at that line, or a negative integer to finish that many lines back from the end.
--   **timeZone** (since 1.8)\
-    Time zone used when displaying the system clock time. Accepts the [JDK TimeZone](http://docs.oracle.com/javase/6/docs/api/java/util/TimeZone.html) ID format.
--   **locale** (since 1.8)\
-    Select the locale to use when displaying the system clock time. Accepts a locale in the format recognised by [commons-lang LocaleUtils.toLocale](https://commons.apache.org/proper/commons-lang/javadocs/api-2.6/org/apache/commons/lang/LocaleUtils.html#toLocale(java.lang.String)).
--   **currentTime** (since 1.8.8)\
+-   `timeZone` (since 1.8)\
+    Time zone used when displaying the system clock time. Accepts the [JDK `TimeZone`](https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html) ID format.
+-   `locale` (since 1.8)\
+    Select the locale to use when displaying the system clock time. Accepts a locale in the format recognised by [Commons Lang `LocaleUtils#toLocale`](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/LocaleUtils.html#toLocale-java.lang.String-).
+-   `currentTime` (since 1.8.8)\
     Display the current time on the Jenkins master instead of reading timestamps from the build.
 
 Reading the timestamps directly from the file system is not recommended, because the format may change.
 
 ### Java API
 
-**Since Timestamper 1.8**
+#### Since Timestamper 1.8
 
-Other plugins can add a [dependency](https://wiki.jenkins-ci.org/display/JENKINS/Dependencies+among+plugins) on the Timestamper plugin, and then use the `TimestamperAPI.read` method to retrieve the timestamps.\
-The `read` method accepts any query string that can be passed to the `/timestamps/` URL.
+Other plugins can add a [dependency](https://wiki.jenkins.io/display/JENKINS/Dependencies+among+plugins) on the Timestamper plugin and then use the `TimestamperAPI#read` method to retrieve the timestamps. The `read` method accepts any query string that can be passed to the `/timestamps/` URL. For example:
 
 ```java
 String query = "time=HH:mm:ss";

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ timestamps {
 Prior to Timestamper 1.8, timestamps can only be recorded within a node.
 
 ```groovy
-node  {
+node {
     wrap([$class: 'TimestamperBuildWrapper']) {
         echo 'hello from Workflow'
     }
@@ -52,7 +52,7 @@ node  {
 
 ## Customization
 
--   The timestamp format can be configured via the **Configure System** page.
+-   The timestamp format can be configured via the **Manage Jenkins** → **Configure System** page.
 -   There is a panel on the left-hand side of the console page which allows either the system clock time or the elapsed time to be displayed.
 -   The time zone used to display the timestamps can be configured by setting [a system property](https://wiki.jenkins.io/display/JENKINS/Change+time+zone).
 
@@ -102,6 +102,9 @@ Reading the timestamps directly from the file system is not recommended, because
 Other plugins can add a [dependency](https://wiki.jenkins.io/display/JENKINS/Dependencies+among+plugins) on the Timestamper plugin and then use the `TimestamperAPI#read` method to retrieve the timestamps. The `read` method accepts any query string that can be passed to the `/timestamps/` URL. For example:
 
 ```java
+import hudson.plugins.timestamper.api.TimestamperAPI;
+import java.io.BufferedReader;
+
 String query = "time=HH:mm:ss";
 try (BufferedReader reader = TimestamperAPI.get().read(build, query)) {
     // read timestamps here

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat.html
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <div>
     The elapsed time format defines how the timestamps will be rendered when the elapsed time option has been selected.
-    The <a href="http://commons.apache.org/proper/commons-lang/javadocs/api-3.1/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> pattern is used.
+    The <a href="https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> pattern is used.
     <p>
     Default is: <code>'&lt;b&gt;'HH:mm:ss.S'&lt;/b&gt; '</code>.
 </div>

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat_de.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat_de.html
@@ -1,6 +1,6 @@
 <div>
     Das Laufzeitformat gibt an, wie die Zeitstempel angezeigt werden, wenn die Laufzeit-Option gew&auml;hlt wurde.
-    Es wird das Muster <a href="http://commons.apache.org/proper/commons-lang/javadocs/api-3.1/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> verwendet.
+    Es wird das Muster <a href="https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> verwendet.
     <p>
     Standard ist: <code>'&lt;b&gt;'HH:mm:ss.S'&lt;/b&gt; '</code>
 </div>

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat_ja.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat_ja.html
@@ -1,5 +1,5 @@
 <div>
-    經過時間のフォーマットは、「經過時間」のオプションが選ばれているときにタイムスタンプをどう表示するかを定義します。<a href="http://commons.apache.org/proper/commons-lang/javadocs/api-3.1/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> パターンを使います。
+    經過時間のフォーマットは、「經過時間」のオプションが選ばれているときにタイムスタンプをどう表示するかを定義します。<a href="https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> パターンを使います。
     <p>
     デフォルト値: <code>'&lt;b&gt;'HH:mm:ss.S'&lt;/b&gt; '</code>
 </div>

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat_zh_TW.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-elapsedTimeFormat_zh_TW.html
@@ -1,6 +1,6 @@
 <div>
     經過時間格式定義了選用「經過時間」選項該怎麼顯示時間戳記。
-    使用 <a href="http://commons.apache.org/proper/commons-lang/javadocs/api-3.1/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> 模式。
+    使用 <a href="https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/time/DurationFormatUtils.html">Commons Lang <code>DurationFormatUtils</code></a> 模式。
     <p>
     預設值是: <code>'&lt;b&gt;'HH:mm:ss.S'&lt;/b&gt; '</code>
 </div>

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-systemTimeFormat.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-systemTimeFormat.html
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 <div>
     The system clock time format defines how the timestamps will be rendered.
-    The <a href="http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html">JDK <code>SimpleDateFormat</code></a> pattern is used.
+    The <a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">JDK <code>SimpleDateFormat</code></a> pattern is used.
     <p>
     Default is: <code>'&lt;b&gt;'HH:mm:ss'&lt;/b&gt; '</code><br>
     For a more detailed format use: <code>yyyy-MM-dd HH:mm:ss.SSS' | '</code>.

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-systemTimeFormat_de.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-systemTimeFormat_de.html
@@ -1,6 +1,6 @@
 <div>
     Das Systemzeitformat gibt an, wie die Zeitstempel angezeigt werden.
-    Es wird das Muster <a href="http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html">JDK <code>SimpleDateFormat</code></a> verwendet.
+    Es wird das Muster <a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">JDK <code>SimpleDateFormat</code></a> verwendet.
     <p>
     Standard ist: <code>'&lt;b&gt;'HH:mm:ss'&lt;/b&gt; '</code><br>
     F&uuml;r ein detaillierteres Format verwenden Sie: <code>yyyy-MM-dd HH:mm:ss.SSS' | '</code>

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-systemTimeFormat_ja.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-systemTimeFormat_ja.html
@@ -1,6 +1,6 @@
 <div>
     システム時刻のフォーマットは、タイムスタンプをどう表示するかを定義します。
-    <a href="http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html">JDK <code>SimpleDateFormat</code></a> パターンを使います。
+    <a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">JDK <code>SimpleDateFormat</code></a> パターンを使います。
     <p>
     デフォルト値: <code>'&lt;b&gt;'HH:mm:ss'&lt;/b&gt; '</code><br>
     より詳細なフォーマット: <code>yyyy-MM-dd HH:mm:ss.SSS' | '</code>

--- a/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-systemTimeFormat_zh_TW.html
+++ b/src/main/resources/hudson/plugins/timestamper/TimestamperConfig/help-systemTimeFormat_zh_TW.html
@@ -1,6 +1,6 @@
 <div>
     系統時間格式定義該怎麼顯示時間戳記。
-    使用 <a href="http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html">JDK <code>SimpleDateFormat</code></a> 模式。
+    使用 <a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">JDK <code>SimpleDateFormat</code></a> 模式。
     <p>
     預設值是: <code>'&lt;b&gt;'HH:mm:ss'&lt;/b&gt; '</code><br>
     想要更詳細的格式，可以用: <code>yyyy-MM-dd HH:mm:ss.SSS' | '</code>


### PR DESCRIPTION
Copyedits the `README` and updates any Javadoc URLs to modern versions. The rendered `README` can be viewed [here](https://github.com/basil/timestamper-plugin/tree/readme) if desired.