### PR TITLE
Add JMH benchmarks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,3 @@
+// Builds the plugin using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+runBenchmarks('jmh-report.json')

--- a/src/test/java/hudson/plugins/timestamper/jmh/BenchmarkRunner.java
+++ b/src/test/java/hudson/plugins/timestamper/jmh/BenchmarkRunner.java
@@ -1,0 +1,33 @@
+package hudson.plugins.timestamper.jmh;
+
+import java.util.concurrent.TimeUnit;
+import jenkins.benchmark.jmh.BenchmarkFinder;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class BenchmarkRunner {
+
+    @Test
+    public void runJmhBenchmarks() throws Exception {
+        ChainedOptionsBuilder options =
+                new OptionsBuilder()
+                        .mode(Mode.AverageTime)
+                        .warmupIterations(2)
+                        .timeUnit(TimeUnit.MICROSECONDS)
+                        .threads(2)
+                        .forks(2)
+                        .shouldFailOnError(true)
+                        .shouldDoGC(true)
+                        .resultFormat(ResultFormatType.JSON)
+                        .result("jmh-report.json");
+
+        // Automatically detect benchmark classes annotated with @JmhBenchmark
+        BenchmarkFinder bf = new BenchmarkFinder(getClass());
+        bf.findBenchmarks(options);
+        new Runner(options.build()).run();
+    }
+}

--- a/src/test/java/hudson/plugins/timestamper/jmh/benchmarks/LogHtmlWriterBenchmark.java
+++ b/src/test/java/hudson/plugins/timestamper/jmh/benchmarks/LogHtmlWriterBenchmark.java
@@ -1,0 +1,97 @@
+package hudson.plugins.timestamper.jmh.benchmarks;
+
+import hudson.Functions;
+import hudson.console.AnnotatedLargeText;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.timestamper.TimestamperBuildWrapper;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Objects;
+import jenkins.benchmark.jmh.JmhBenchmark;
+import jenkins.benchmark.jmh.JmhBenchmarkState;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+@JmhBenchmark
+public class LogHtmlWriterBenchmark {
+
+    public static class JenkinsState extends JmhBenchmarkState {
+        FreeStyleBuild freestyleBuild = null;
+        WorkflowRun pipelineBuild = null;
+
+        @Override
+        public void setup() throws Exception {
+            Jenkins jenkins = getJenkins();
+
+            FreeStyleProject freestyleProject =
+                    jenkins.createProject(FreeStyleProject.class, "timestamper-freestyle");
+            freestyleProject
+                    .getBuildersList()
+                    .add(
+                            Functions.isWindows()
+                                    ? new BatchFile("FOR /L %%n IN (1,1,10000) DO ECHO %%n")
+                                    : new Shell("for i in $(seq 1 1 10000); do echo $i; done"));
+            freestyleProject.getBuildWrappersList().add(new TimestamperBuildWrapper());
+            freestyleBuild = freestyleProject.scheduleBuild2(0).get();
+
+            WorkflowJob pipelineProject =
+                    jenkins.createProject(WorkflowJob.class, "timestamper-pipeline");
+            pipelineProject.setDefinition(
+                    new CpsFlowDefinition(
+                            "node {\n"
+                                    + "  if (isUnix()) {\n"
+                                    + "    sh 'for i in $(seq 1 1 10000); do echo $i; done'\n"
+                                    + "  } else {\n"
+                                    + "    bat 'FOR /L %%n IN (1,1,10000) DO ECHO %%n'\n"
+                                    + "  }\n"
+                                    + "}\n",
+                            true));
+            pipelineBuild = pipelineProject.scheduleBuild2(0).get();
+        }
+    }
+
+    public static class BlackholeWriter extends Writer {
+        private final Blackhole blackhole;
+
+        public BlackholeWriter(Blackhole blackhole) {
+            super();
+            this.blackhole = Objects.requireNonNull(blackhole);
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            blackhole.consume(cbuf);
+            blackhole.consume(off);
+            blackhole.consume(len);
+        }
+
+        @Override
+        public void flush() throws IOException {}
+
+        @Override
+        public void close() throws IOException {}
+    }
+
+    @Benchmark
+    public void logHtmlWriterFreestyleBenchmark(JenkinsState state, Blackhole blackhole)
+            throws Exception {
+        AnnotatedLargeText logText = state.freestyleBuild.getLogText();
+        long r = logText.writeHtmlTo(0, new BlackholeWriter(blackhole));
+        blackhole.consume(r);
+    }
+
+    @Benchmark
+    public void logHtmlWriterPipelineBenchmark(JenkinsState state, Blackhole blackhole)
+            throws Exception {
+        AnnotatedLargeText logText = state.pipelineBuild.getLogText();
+        long r = logText.writeHtmlTo(0, new BlackholeWriter(blackhole));
+        blackhole.consume(r);
+    }
+}


### PR DESCRIPTION
Adds two JMH benchmarks for the Timestamper plugin: one for Freestyle jobs and one for Pipeline jobs.

The normal code path for streaming HTML-annotated console logs is [`Run#writeLogTo(long, XMLOutput)`](https://github.com/jenkinsci/jenkins/blob/06712954c2950c64063be536cd5fa92493002935/core/src/main/java/hudson/model/Run.java#L1506-L1513), which calls `getLogText().writeHtmlTo(offset, out.asWriter())`. This benchmark works the same way, but instead of writing to an `XMLOutput` it writes to a `BlackholeWriter`, which simply sends all output down a black hole. Thus the benchmark simply exercises the `getLogText()` method (to construct an instance of `AnnotatedLargeText`) and `AnnotatedLargeText#writeHtmlTo(long, Writer)` (which streams the log to the output `Writer`, annotating it all registered `ConsoleAnnotator`s). This is the simplest code path I could find that realistically exercises all registered `ConsoleAnnotator`s.

The benchmark runner is [shamelessly stolen from `role-strategy-plugin`](https://github.com/jenkinsci/role-strategy-plugin/blob/master/src/test/java/jmh/BenchmarkRunner.java).

Interestingly enough, I discovered the Pipeline case was consistently about 30% slower than the Freestyle case. I looked into this further and found that about 12% of that had nothing to do with Timestamper but was related to the different way that Pipeline stores and streams raw logs. But even taking that into account, I found a way to get a small 10% win in the Pipeline case, which I will file as a separate PR.