### PR TITLE
Use MarkupText#getText instead of MarkupText#toString

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
@@ -105,7 +105,9 @@ public class TimestampLogFileLineAccessor implements Closeable {
             // If a timestamps file is not present, attempt to read the timestamp from the log file.
             // The log file is decorated with GlobalDecorator for Pipeline builds of version 1.9 or
             // later.
-            timestamp = GlobalAnnotator.parseTimestamp(logFileLine, build).orElse(null);
+            timestamp =
+                    GlobalAnnotator.parseTimestamp(logFileLine, build.getStartTimeInMillis())
+                            .orElse(null);
             if (timestamp != null) {
                 // If we succeeded, then the log file was decorated by GlobalDecorator. Strip the
                 // timestamp decoration from the front of the line.

--- a/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
@@ -105,9 +105,7 @@ public class TimestampLogFileLineAccessor implements Closeable {
             // If a timestamps file is not present, attempt to read the timestamp from the log file.
             // The log file is decorated with GlobalDecorator for Pipeline builds of version 1.9 or
             // later.
-            timestamp =
-                    GlobalAnnotator.parseTimestamp(logFileLine, 0, build.getStartTimeInMillis())
-                            .orElse(null);
+            timestamp = GlobalAnnotator.parseTimestamp(logFileLine, build).orElse(null);
             if (timestamp != null) {
                 // If we succeeded, then the log file was decorated by GlobalDecorator. Strip the
                 // timestamp decoration from the front of the line.

--- a/src/main/java/hudson/plugins/timestamper/pipeline/GlobalAnnotator.java
+++ b/src/main/java/hudson/plugins/timestamper/pipeline/GlobalAnnotator.java
@@ -78,7 +78,8 @@ public final class GlobalAnnotator extends ConsoleAnnotator<Object> {
         } else {
             return null;
         }
-        parseTimestamp(text.getText(), build)
+        long buildStartTime = build.getStartTimeInMillis();
+        parseTimestamp(text.getText(), buildStartTime)
                 .ifPresent(
                         timestamp -> {
                             TimestampFormat format = TimestampFormatProvider.get();
@@ -90,14 +91,14 @@ public final class GlobalAnnotator extends ConsoleAnnotator<Object> {
 
     /** Parse this line for a timestamp if such a timestamp is present. */
     @Restricted(NoExternalUse.class)
-    public static Optional<Timestamp> parseTimestamp(String text, Run<?, ?> build) {
+    public static Optional<Timestamp> parseTimestamp(String text, long buildStartTime) {
         if (text.startsWith("[")) {
             int end = text.indexOf(']');
             if (end != -1) {
                 try {
                     long millisSinceEpoch = ZonedDateTime.parse(text.substring(1, end), GlobalDecorator.UTC_MILLIS).toInstant().toEpochMilli();
                     // Alternately: Instant.parse(text.substring(1, end)).toEpochMilli()
-                    Timestamp timestamp = new Timestamp(millisSinceEpoch - build.getStartTimeInMillis(), millisSinceEpoch);
+                    Timestamp timestamp = new Timestamp(millisSinceEpoch - buildStartTime, millisSinceEpoch);
                     return Optional.of(timestamp);
                 } catch (DateTimeParseException x) {
                     // something else, ignore

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -144,9 +144,7 @@ public class PipelineTest {
         r.assertLogContains("foo", build);
         List<String> unstampedLines = new ArrayList<>();
         for (String line : build.getLog(Integer.MAX_VALUE)) {
-            assertTrue(
-                    GlobalAnnotator.parseTimestamp(line, 0, build.getStartTimeInMillis())
-                            .isPresent());
+            assertTrue(GlobalAnnotator.parseTimestamp(line, build).isPresent());
             unstampedLines.add(line.substring(27));
         }
         TimestamperApiTestUtil.timestamperApi(build, unstampedLines);
@@ -167,8 +165,7 @@ public class PipelineTest {
             assertEquals(
                     line,
                     line.contains("foo"),
-                    GlobalAnnotator.parseTimestamp(line, 0, build.getStartTimeInMillis())
-                            .isPresent());
+                    GlobalAnnotator.parseTimestamp(line, build).isPresent());
         }
     }
 }

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -144,7 +144,8 @@ public class PipelineTest {
         r.assertLogContains("foo", build);
         List<String> unstampedLines = new ArrayList<>();
         for (String line : build.getLog(Integer.MAX_VALUE)) {
-            assertTrue(GlobalAnnotator.parseTimestamp(line, build).isPresent());
+            assertTrue(
+                    GlobalAnnotator.parseTimestamp(line, build.getStartTimeInMillis()).isPresent());
             unstampedLines.add(line.substring(27));
         }
         TimestamperApiTestUtil.timestamperApi(build, unstampedLines);
@@ -165,7 +166,7 @@ public class PipelineTest {
             assertEquals(
                     line,
                     line.contains("foo"),
-                    GlobalAnnotator.parseTimestamp(line, build).isPresent());
+                    GlobalAnnotator.parseTimestamp(line, build.getStartTimeInMillis()).isPresent());
         }
     }
 }


### PR DESCRIPTION
### Summary

This is a minor performance improvement to the code path that displays timestamp-annotated console logs for Pipeline jobs.

### Background

`GlobalAnnotator#annotate` is called with `MarkupText` as input. `MarkupText` represents a single log file line, and `GlobalAnnotator` needs to parse the log file line to determine whether or not it contains a timestamp. If it does contain a timestamp, `GlobalAnnotator` needs to parse it and then format it according to the user's configuration.

`MarkupText` has two main fields: `String text` and `List<Tag> tags`. In the context of Pipeline jobs, `text` is something like `[2020-03-01T16:23:50.739Z] [Pipeline] echo` and `tags` is something like `["<span class="pipeline-new-node" nodeId="9" enclosingId="6">", "<span style="color: #CD0000;">", "</span>", "</span>"]`. Note that the raw `text` contains the timestamp, which was previously added to the beginning of the line by `GlobalDecorator`.

### Problem

The current logic in `GlobalAnnotator#annotate` unconditionally calls `MarkupText#toString(boolean)`, which renders the `MarkupText` object into a `String`, e.g. `<span class="pipeline-new-node" nodeId="9" enclosingId="6"><span style="color: #CD0000;">[2020-03-01T16:25:58.928Z] [Pipeline] echo
</span></span>`. The current logic then checks if the `String` starts with `<span class="pipeline-new-node"` or `<span style="color`, adjusting a starting index appropriately. It then attempts to parse the timestamp starting at that index.

### Evaluation

The logic I described above is unnecessary. The current logic starts with a raw log file line (i.e., `MarkupText#text`), adds the tags contained in `MarkupText#tags` (via `MarkupText#toString(boolean)`), then seeks around the tags (via `String#startsWith` calls). This could be avoided by directly dealing with the original text without adding any tags in the first place.

### Solution

Try to parse the timestamp from the raw log line (from `MarkupText#getText`) rather than the marked-up version (from `MarkupText#toString(boolean)`). The timestamp is always at the beginning of this `String`, so there is no need to seek around markup looking for it. This not only makes the code more efficient, but it also cleans up some ugly logic and makes the code simpler.

### Implementation

Since we no longer need a starting index, I removed the `int` parameter from `GlobalAnnotator#parseTimestamp`. While I was here, I also simplified the method's signature to take a `Run<?, ?>` rather than a build start time, which deduplicates a small bit of code from each caller.

### Performance Testing

I ran the new benchmarks from #56 a few times before and after this change. This change consistently results in a modest ~10% performance improvement when displaying Pipeline logs, from about 10.5 ms to about 9.5 ms when rendering 20,000 lines of console output. Freestyle jobs take about 7.5 ms, but at least part of that is due to the simpler storage of logs for Freestyle jobs, since  rendering the same Pipeline console output without timestamps still took about 8.5 ms. The remaining 1 ms performance gap between Freestyle and Pipeline makes some sense intuitively, as Freestyle timestamps are stored in a highly optimized format in a separate log file, while in Pipeline they need to be first extracted from the beginning of a raw log line and then parsed.