### PR TITLE
Replace usage of buildPlugin.recommendedConfigurations() with explicit configurations in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,14 @@
 // Builds the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+  // Test the long-term support end of the compatibility spectrum (i.e., the minimum required
+  // Jenkins version).
+  [ platform: 'linux', jdk: '8', jenkins: null ],
+
+  // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
+  [ platform: 'linux', jdk: '8', jenkins: '2.222.4', javaLevel: '8' ],
+  [ platform: 'windows', jdk: '8', jenkins: '2.222.4', javaLevel: '8' ],
+
+  // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
+  [ platform: 'linux', jdk: '11', jenkins: '2.222.4', javaLevel: '8' ],
+])
 runBenchmarks('jmh-report.json')


### PR DESCRIPTION
There has recently been some instability around `buildPlugin.recommendedConfigurations()` and even some talk of deprecating it entirely, so let's stop relying on it and define our own testing matrix. I've provided comments explaining the matrix I've chosen. The matrix is similar to that used by `buildPlugin.recommendedConfigurations()`. There are two differences:

- I am using the latest LTS release rather than 2.164.1 to get testing on the bleeding edge of the compatibility spectrum.
- I am adding a recent LTS release Java 8 build on Linux in addition to the recent lts release Java 8 build on Windows. This is to help when debugging Windows failures by providing an apples-to-apples comparison between Windows and non-Windows. Without adding this to the matrix, one would not be able to tell if a Windows test failure was due to the use of Windows or due to the use of a recent LTS release.