### PR TITLE
[JENKINS-62445] Add and check JCasC compatibility for timestamper plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
+    <jcasc.version>1.36</jcasc.version>
   </properties>
 
   <build>
@@ -178,6 +179,18 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ansicolor</artifactId>
       <version>0.6.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <version>${jcasc.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/timestamper/TimestamperConfig.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestamperConfig.java
@@ -45,6 +45,7 @@ import javax.servlet.ServletException;
 import jenkins.YesNoMaybe;
 import jenkins.model.GlobalConfiguration;
 import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.QueryParameter;
 
 /**
@@ -53,6 +54,7 @@ import org.kohsuke.stapler.QueryParameter;
  * @author Frederik Fromm
  */
 @Extension(dynamicLoadable = YesNoMaybe.YES)
+@Symbol("timestamper")
 public final class TimestamperConfig extends GlobalConfiguration {
 
   /**

--- a/src/test/java/hudson/plugins/timestamper/ConfigurationAsCodeTest.java
+++ b/src/test/java/hudson/plugins/timestamper/ConfigurationAsCodeTest.java
@@ -1,0 +1,66 @@
+package hudson.plugins.timestamper;
+
+import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ConfigurationAsCodeTest {
+
+    @Rule public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("Default.yml")
+    public void testDefault() {
+        TimestamperConfig timestamperConfig = TimestamperConfig.get();
+        assertThat(timestamperConfig.getSystemTimeFormat(), containsString("HH:mm:ss"));
+        assertThat(timestamperConfig.getElapsedTimeFormat(), containsString("HH:mm:ss.S"));
+        assertFalse(timestamperConfig.isAllPipelines());
+    }
+
+    @Test
+    @ConfiguredWithCode("Customized.yml")
+    public void testCustomTimeFormat() {
+        TimestamperConfig timestamperConfig = TimestamperConfig.get();
+        assertThat(
+                timestamperConfig.getSystemTimeFormat(), containsString("yyyy-MM-dd HH:mm:ss.SSS"));
+        assertThat(timestamperConfig.getElapsedTimeFormat(), containsString("HH:mm:ss.SSS"));
+        assertTrue(timestamperConfig.isAllPipelines());
+    }
+
+    @Test
+    @ConfiguredWithCode("EmptyTimeFormat.yml")
+    public void testEmptyTimeFormat() {
+        TimestamperConfig timestamperConfig = TimestamperConfig.get();
+        assertThat(timestamperConfig.getSystemTimeFormat(), is(emptyString()));
+        assertThat(timestamperConfig.getElapsedTimeFormat(), is(emptyString()));
+        assertFalse(timestamperConfig.isAllPipelines());
+    }
+
+    @Test
+    @ConfiguredWithCode("Customized.yml")
+    public void testConfigAsCodeExport() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode timestamperConfig = getUnclassifiedRoot(context).get("timestamper");
+        String exported = toYamlString(timestamperConfig);
+        String expected = toStringFromYamlFile(this, "CustomizedExport.yml");
+        assertEquals(expected, exported);
+    }
+}

--- a/src/test/resources/hudson/plugins/timestamper/Customized.yml
+++ b/src/test/resources/hudson/plugins/timestamper/Customized.yml
@@ -1,0 +1,6 @@
+---
+unclassified:
+  timestamper:
+    systemTimeFormat: "'<b>'yyyy-MM-dd HH:mm:ss.SSS'</b> '"
+    elapsedTimeFormat: "'<b>'HH:mm:ss.SSS'</b> '"
+    allPipelines: true

--- a/src/test/resources/hudson/plugins/timestamper/CustomizedExport.yml
+++ b/src/test/resources/hudson/plugins/timestamper/CustomizedExport.yml
@@ -1,0 +1,3 @@
+allPipelines: true
+elapsedTimeFormat: "'<b>'HH:mm:ss.SSS'</b> '"
+systemTimeFormat: "'<b>'yyyy-MM-dd HH:mm:ss.SSS'</b> '"

--- a/src/test/resources/hudson/plugins/timestamper/Default.yml
+++ b/src/test/resources/hudson/plugins/timestamper/Default.yml
@@ -1,0 +1,3 @@
+---
+unclassified:
+  timestamper:

--- a/src/test/resources/hudson/plugins/timestamper/EmptyTimeFormat.yml
+++ b/src/test/resources/hudson/plugins/timestamper/EmptyTimeFormat.yml
@@ -1,0 +1,5 @@
+---
+unclassified:
+  timestamper:
+    systemTimeFormat: ""
+    elapsedTimeFormat: ""


### PR DESCRIPTION
See [JENKINS-62445](https://issues.jenkins-ci.org/browse/JENKINS-62445). Adds a `@Symbol` annotation to the Timestamper configuration class as suggested in [Step 6](https://github.com/jenkinsci/configuration-as-code-plugin/blob/91eef621090e4eb4e0944decb02254515197922c/docs/PLUGINS.md#step-6) of the CasC guide for plugin developers. Also adds tests as described in the "[how to test](https://github.com/jenkinsci/configuration-as-code-plugin/blob/91eef621090e4eb4e0944decb02254515197922c/docs/PLUGINS.md#how-to-test)" section of the same guide.

*Note*: [JENKINS-62445](https://issues.jenkins-ci.org/browse/JENKINS-62445) stated:

> Avoid the unclassified group.

However, I do not see any way to do so. `GlobalConfigurationCategory#all()` reveals the following three standard groups:

- `jenkins.model.GlobalConfigurationCategory$Unclassified`
- `jenkins.model.GlobalConfigurationCategory$Security`
- `jenkins.tools.ToolConfigurationCategory`

Besides the unclassified group, there are only two standard groups: Security and Tool. The timestamper configuration falls under neither. Nor does it make sense to define a `GlobalConfigurationCategory` within Timestamper, as the Timestamper configuration is not complex enough to warrant its own group. Rather, it would make sense as part of some broadly scoped standard group. Such a group does not currently exist, and creating one is outside the scope of this PR. I suggest the team that filed [JENKINS-62445](https://issues.jenkins-ci.org/browse/JENKINS-62445) create a set of standard groups before asking developers to avoid the unclassified group.