### PR TITLE
Use plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.1.12</version>
+      <version>3.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Updates #35 for June 2020. As a bonus, I upgraded the plugin POM and `nl.jqno.equalsverifier` to the latest versions.