### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.2</version>
+    <version>4.4</version>
     <relativePath />
   </parent>
 
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ant</artifactId>
-      <version>1.2</version>
+      <version>1.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -181,7 +181,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.3</version>
+      <version>3.4.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Updates the following dependencies to the latest versions:

- Jenkins plugin POM (4.2 to 4.4)
- Ant plugin used in tests (1.2 to 1.11)
- EqualsVerifier used in tests (3.3 to 3.4.1)