### PR TITLE
Restore compatibility with old JCasC config

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/TimestamperConfig.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestamperConfig.java
@@ -54,7 +54,7 @@ import org.kohsuke.stapler.QueryParameter;
  * @author Frederik Fromm
  */
 @Extension(dynamicLoadable = YesNoMaybe.YES)
-@Symbol("timestamper")
+@Symbol({"timestamper", "timestamperConfig"})
 public final class TimestamperConfig extends GlobalConfiguration {
 
   /**


### PR DESCRIPTION
Tried upgrading today and got:

```
jenkins    | io.jenkins.plugins.casc.ConfiguratorException: Invalid configuration elements for type class jenkins.model.GlobalConfigurationCategory$Unclassified : timestamperConfig.
jenkins    | Available attributes : administrativeMonitorsConfiguration, ansiColorBuildWrapper, appInsightsGlobalConfig, artifactManager, azureKeyVault, bitbucketEndpointConfiguration, buildDiscarders, buildMonitorView, casCGlobalConfig, defaultFolderConfiguration, defaultView, envVarsFilter, fingerprints, gitHubConfiguration, gitHubPluginConfig, gitSCM, globalDefaultFlowDurabilityLevel, globalLibraries, httpRequestGlobalConfig, jacoco, jiraGlobalConfiguration, location, lockableResourcesManager, mailer, masterBuild, mavenModuleSet, metricsAccessKey, myView, nodeProperties, pipeline-model-docker, plugin, pollSCM, projectNamingStrategy, prometheusConfiguration, quietPeriod, resourceRoot, scmRetryCount, shell, simple-theme-plugin, slackNotifier, sonarGlobalConfiguration, themeManager, timestamper, usageStatistics, viewsTabBar
```

This allows old scripts to still work and the default config will be the new one

cc @basil 