### PR TITLE
Make the sidebar settings compatible with the new design

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/settingsForm.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/settingsForm.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+<form>
+    <label>
+        <input type="radio" name="timestamps" id="timestamper-systemTime">${%System clock time}</input>
+    </label>
+    <br/>
+    <label>
+        <input type="checkbox" id="timestamper-localTime" style="margin-left: 15px;">${%Use browser timezone}</input>
+    </label>
+    <br/>
+    <label>
+        <input type="radio" name="timestamps" id="timestamper-elapsedTime">${%Elapsed time}</input>
+    </label>
+    <br/>
+    <label>
+        <input type="radio" name="timestamps" id="timestamper-none">${%None}</input>
+    </label>
+</form>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/settingsForm.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/settingsForm.jelly
@@ -4,15 +4,12 @@
     <label>
         <input type="radio" name="timestamps" id="timestamper-systemTime">${%System clock time}</input>
     </label>
-    <br/>
     <label>
         <input type="checkbox" id="timestamper-localTime" style="margin-left: 15px;">${%Use browser timezone}</input>
     </label>
-    <br/>
     <label>
         <input type="radio" name="timestamps" id="timestamper-elapsedTime">${%Elapsed time}</input>
     </label>
-    <br/>
     <label>
         <input type="radio" name="timestamps" id="timestamper-none">${%None}</input>
     </label>

--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
@@ -32,17 +32,18 @@ THE SOFTWARE.
   <j:set var="rawMinorVersion" value="${versionParts[1].split('-')}" />
   <j:set var="minorVersion" value="${rawMinorVersion[0]}" />
   <l:ajax>
+    <style>
+      .timestamper-form-pane {
+        padding: .5rem 1rem;
+        clear: both
+      }
+      .timestamper-form-pane label {
+        line-height: 2rem;
+        display: block;
+      }
+    </style>
     <j:choose>
       <j:when test="${(majorVersion ge 2 and minorVersion ge 238) or majorVersion > 2}">
-        <style>
-          .timestamper-form-pane {
-            padding: .5rem 1rem;
-            clear: both
-          }
-          .timestamper-form-pane label {
-            line-height: 2rem;
-          }
-        </style>
         <div>
           <div class="pane-header col-xs-24">
             <span class="pane-header-title">${%Timestamps}</span>
@@ -62,7 +63,7 @@ THE SOFTWARE.
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="timestamper-form-pane">
               <st:include page="settingsForm.jelly"/>
             </td>
           </tr>

--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
@@ -23,36 +23,51 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  <j:new var="h" className="hudson.Functions" />
+  ${h.initPageVariables(context)}
+
+  <j:set var="versionParts" value="${h.version.split('\.')}" />
+  <j:set var="majorVersion" value="${versionParts[0]}" />
+  <j:set var="rawMinorVersion" value="${versionParts[1].split('-')}" />
+  <j:set var="minorVersion" value="${rawMinorVersion[0]}" />
   <l:ajax>
-    <table class="pane">
-      <tr>
-        <td class="pane-header">
-          <span style="text-align:left;">${%Timestamps}</span>
-          <span style="float:right;"><a class="timestamper-plain-text" href="${it.plainTextUrl}">${%View as plain text}</a></span>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <form>
-            <label>
-              <input type="radio" name="timestamps" id="timestamper-systemTime">${%System clock time}</input>
-            </label>
-            <br/>
-            <label>
-              <input type="checkbox" id="timestamper-localTime" style="margin-left: 15px;">${%Use browser timezone}</input>
-            </label>
-            <br/>
-            <label>
-              <input type="radio" name="timestamps" id="timestamper-elapsedTime">${%Elapsed time}</input>
-            </label>
-            <br/>
-            <label>
-              <input type="radio" name="timestamps" id="timestamper-none">${%None}</input>
-            </label>
-          </form>
-        </td>
-      </tr>
-    </table>
+    <j:choose>
+      <j:when test="${(majorVersion ge 2 and minorVersion ge 238) or majorVersion > 2}">
+        <style>
+          .timestamper-form-pane {
+            padding: .5rem 1rem;
+            clear: both
+          }
+          .timestamper-form-pane label {
+            line-height: 2rem;
+          }
+        </style>
+        <div>
+          <div class="pane-header col-xs-24">
+            <span class="pane-header-title">${%Timestamps}</span>
+            <span><a class="timestamper-plain-text" href="${it.plainTextUrl}">${%View as plain text}</a></span>
+          </div>
+          <div class="timestamper-form-pane">
+            <st:include page="settingsForm.jelly"/>
+          </div>
+        </div>
+      </j:when>
+      <j:otherwise>
+        <table class="pane">
+          <tr>
+            <td class="pane-header">
+              <span style="text-align:left;">${%Timestamps}</span>
+              <span style="float:right;"><a class="timestamper-plain-text" href="${it.plainTextUrl}">${%View as plain text}</a></span>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <st:include page="settingsForm.jelly"/>
+            </td>
+          </tr>
+        </table>
+      </j:otherwise>
+    </j:choose>
   </l:ajax>
 </j:jelly>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1105305/96055684-027b3400-0e85-11eb-9b59-6a96fbe83c61.png)


After:
![image](https://user-images.githubusercontent.com/1105305/96055486-7ec14780-0e84-11eb-8be4-edc078e84025.png)


In theory it's possible to use `<div>` with the new design for both new and old cores, but this seems safer. When core version gets bumped beyond 2.238 this can be simplified again.

CC @fqueiruga @timja 