### PR TITLE
Bump bom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.204.x</artifactId>
-        <version>13</version>
+        <version>15</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
We finally resolved the issues but had to exclude the timestamper test till jackson is upgraded in bom.
https://github.com/jenkinsci/bom/pull/294#issuecomment-710770375

this will resolve the issue and we can re-enable the test once this is released (no rush)