### PR TITLE
Removing some Guava usages

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/action/TimestampsActionOutput.java
+++ b/src/main/java/hudson/plugins/timestamper/action/TimestampsActionOutput.java
@@ -23,7 +23,7 @@
  */
 package hudson.plugins.timestamper.action;
 
-import com.google.common.base.Joiner;
+import hudson.Util;
 import hudson.console.ConsoleNote;
 import hudson.model.Run;
 import hudson.plugins.timestamper.Timestamp;
@@ -95,7 +95,7 @@ public class TimestampsActionOutput {
       for (Function<Timestamp, String> format : query.timestampFormats) {
         parts.add(format.apply(currentTimestamp));
       }
-      String result = Joiner.on(' ').join(parts) + "\n";
+      String result = Util.join(parts, " ") + "\n";
       return new BufferedReader(new StringReader(result));
     }
 
@@ -165,7 +165,7 @@ public class TimestampsActionOutput {
               for (Function<Timestamp, String> format : query.timestampFormats) {
                 parts.add(format.apply(timestamp.get()));
               }
-              result = Joiner.on(' ').join(parts);
+              result = Util.join(parts, " ");
             }
             if (query.appendLogLine) {
               result += "  ";

--- a/src/main/java/hudson/plugins/timestamper/action/TimestampsActionOutput.java
+++ b/src/main/java/hudson/plugins/timestamper/action/TimestampsActionOutput.java
@@ -23,7 +23,6 @@
  */
 package hudson.plugins.timestamper.action;
 
-import hudson.Util;
 import hudson.console.ConsoleNote;
 import hudson.model.Run;
 import hudson.plugins.timestamper.Timestamp;
@@ -95,7 +94,7 @@ public class TimestampsActionOutput {
       for (Function<Timestamp, String> format : query.timestampFormats) {
         parts.add(format.apply(currentTimestamp));
       }
-      String result = Util.join(parts, " ") + "\n";
+      String result = String.join(" ", parts) + "\n";
       return new BufferedReader(new StringReader(result));
     }
 
@@ -165,7 +164,7 @@ public class TimestampsActionOutput {
               for (Function<Timestamp, String> format : query.timestampFormats) {
                 parts.add(format.apply(timestamp.get()));
               }
-              result = Util.join(parts, " ");
+              result = String.join(" ", parts);
             }
             if (query.appendLogLine) {
               result += "  ";

--- a/src/main/java/hudson/plugins/timestamper/io/DumpTimestamps.java
+++ b/src/main/java/hudson/plugins/timestamper/io/DumpTimestamps.java
@@ -23,13 +23,14 @@
  */
 package hudson.plugins.timestamper.io;
 
-import com.google.common.base.Joiner;
 import com.google.common.io.CountingInputStream;
 import com.google.common.io.Files;
+import hudson.Util;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -50,7 +51,7 @@ public final class DumpTimestamps {
     if (args.length == 0) {
       throw new IllegalArgumentException("no command-line arguments");
     }
-    File timestamperDir = new File(Joiner.on(' ').join(args));
+    File timestamperDir = new File(Util.join(Arrays.asList(args), " "));
     dump(timestamperDir, "timestamps", 1);
     System.out.println();
     dump(timestamperDir, "timeshifts", 2);
@@ -70,12 +71,12 @@ public final class DumpTimestamps {
     while (inputStream.getCount() < fileContents.length) {
       values.add(Varint.read(inputStream));
       if (values.size() == columns) {
-        System.out.println(Joiner.on('\t').join(values));
+        System.out.println(Util.join(values, "\t"));
         values.clear();
       }
     }
     if (!values.isEmpty()) {
-      System.out.println(Joiner.on('\t').join(values));
+      System.out.println(Util.join(values, "\t"));
     }
   }
 

--- a/src/main/java/hudson/plugins/timestamper/io/DumpTimestamps.java
+++ b/src/main/java/hudson/plugins/timestamper/io/DumpTimestamps.java
@@ -25,12 +25,10 @@ package hudson.plugins.timestamper.io;
 
 import com.google.common.io.CountingInputStream;
 import com.google.common.io.Files;
-import hudson.Util;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -51,7 +49,7 @@ public final class DumpTimestamps {
     if (args.length == 0) {
       throw new IllegalArgumentException("no command-line arguments");
     }
-    File timestamperDir = new File(Util.join(Arrays.asList(args), " "));
+    File timestamperDir = new File(String.join(" ", args));
     dump(timestamperDir, "timestamps", 1);
     System.out.println();
     dump(timestamperDir, "timeshifts", 2);
@@ -67,16 +65,16 @@ public final class DumpTimestamps {
     byte[] fileContents = Files.toByteArray(file);
     CountingInputStream inputStream =
         new CountingInputStream(new ByteArrayInputStream(fileContents));
-    List<Long> values = new ArrayList<>();
+    List<String> values = new ArrayList<>();
     while (inputStream.getCount() < fileContents.length) {
-      values.add(Varint.read(inputStream));
+      values.add(Long.toString(Varint.read(inputStream)));
       if (values.size() == columns) {
-        System.out.println(Util.join(values, "\t"));
+        System.out.println(String.join("\t", values));
         values.clear();
       }
     }
     if (!values.isEmpty()) {
-      System.out.println(Util.join(values, "\t"));
+      System.out.println(String.join("\t", values));
     }
   }
 

--- a/src/main/java/hudson/plugins/timestamper/io/TimeShiftsReader.java
+++ b/src/main/java/hudson/plugins/timestamper/io/TimeShiftsReader.java
@@ -23,7 +23,6 @@
  */
 package hudson.plugins.timestamper.io;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CountingInputStream;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -72,7 +71,7 @@ class TimeShiftsReader implements Serializable {
    */
   Optional<Long> getTime(long timestampEntry) throws IOException {
     if (timeShifts == null) {
-      timeShifts = ImmutableMap.copyOf(readTimeShifts());
+      timeShifts = Collections.unmodifiableMap(readTimeShifts());
     }
     return Optional.ofNullable(timeShifts.get(timestampEntry));
   }

--- a/src/test/java/hudson/plugins/timestamper/action/TimestampsActionQueryTest.java
+++ b/src/test/java/hudson/plugins/timestamper/action/TimestampsActionQueryTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import hudson.Util;
 import hudson.plugins.timestamper.format.ElapsedTimestampFormat;
 import hudson.plugins.timestamper.format.SystemTimestampFormat;
 import java.util.ArrayList;
@@ -214,7 +213,7 @@ public class TimestampsActionQueryTest {
         List<String> params = new ArrayList<>();
         startLine.ifPresent(integer -> params.add("startLine=" + integer));
         endLine.ifPresent(integer -> params.add("endLine=" + integer));
-        String query = Util.join(params, "&");
+        String query = String.join("&", params);
 
         if (!query.isEmpty()) {
           testCases.add(

--- a/src/test/java/hudson/plugins/timestamper/action/TimestampsActionQueryTest.java
+++ b/src/test/java/hudson/plugins/timestamper/action/TimestampsActionQueryTest.java
@@ -27,16 +27,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import hudson.Util;
 import hudson.plugins.timestamper.format.ElapsedTimestampFormat;
 import hudson.plugins.timestamper.format.SystemTimestampFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -213,7 +214,7 @@ public class TimestampsActionQueryTest {
         List<String> params = new ArrayList<>();
         startLine.ifPresent(integer -> params.add("startLine=" + integer));
         endLine.ifPresent(integer -> params.add("endLine=" + integer));
-        String query = Joiner.on('&').join(params);
+        String query = Util.join(params, "&");
 
         if (!query.isEmpty()) {
           testCases.add(
@@ -229,8 +230,10 @@ public class TimestampsActionQueryTest {
     testCases.add(new Object[] {"endLine=invalid", NumberFormatException.class});
 
     // Append log line
-    Map<String, Boolean> appendLogParams =
-        ImmutableMap.of("appendLog", true, "appendLog=true", true, "appendLog=false", false);
+    Map<String, Boolean> appendLogParams = new HashMap<>();
+    appendLogParams.put("appendLog", true);
+    appendLogParams.put("appendLog=true", true);
+    appendLogParams.put("appendLog=false", false);
     for (Map.Entry<String, Boolean> mapEntry : appendLogParams.entrySet()) {
       String appendLogParam = mapEntry.getKey();
       boolean appendLog = mapEntry.getValue();


### PR DESCRIPTION
See [the mailing list thread](https://groups.google.com/g/jenkinsci-dev/c/aYUJ4VuOuVc). Removing the following Guava usages:

- `com/google/common/collect/ImmutableMap`
- `com/google/common/base/Joiner#join(Ljava/lang/Iterable;)Ljava/lang/String;`
- `com/google/common/base/Joiner#join([Ljava/lang/Object;)Ljava/lang/String;`