### PR TITLE
Use initial value outside of byte bound to avoid collisions with some unicode characters

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/TimestamperOutputStream.java
+++ b/src/main/java/hudson/plugins/timestamper/TimestamperOutputStream.java
@@ -39,6 +39,7 @@ import java.util.logging.Logger;
 final class TimestamperOutputStream extends OutputStream {
 
   private static final Logger LOGGER = Logger.getLogger(TimestamperOutputStream.class.getName());
+  public static final byte NEWLINE = (byte) 0x0A;
 
   /** The delegate output stream. */
   private final OutputStream delegate;
@@ -49,8 +50,8 @@ final class TimestamperOutputStream extends OutputStream {
   /** Byte array that is re-used each time the {@link #write(int)} method is called. */
   private final byte[] oneElementByteArray = new byte[1];
 
-  /** The last processed character, or {@code -1} for the start of the stream. */
-  private int previousCharacter = -1;
+  /** The last processed character, or {@code Integer.MIN_VALUE} for the start of the stream. */
+  private int previousCharacter = Integer.MIN_VALUE;
 
   /** Set to {@code true} when an error occurs while writing the time-stamps. */
   private boolean writeError;
@@ -90,10 +91,9 @@ final class TimestamperOutputStream extends OutputStream {
   }
 
   private void writeTimestamps(byte[] b, int off, int len) {
-    byte newlineCharacter = (byte) 0x0A;
     int lineStartCount = 0;
     for (int i = off; i < off + len; i++) {
-      if (previousCharacter == -1 || previousCharacter == newlineCharacter) {
+      if (previousCharacter == Integer.MIN_VALUE || previousCharacter == NEWLINE) {
         lineStartCount++;
       }
       previousCharacter = b[i];

--- a/src/test/java/hudson/plugins/timestamper/TimestamperOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/timestamper/TimestamperOutputStreamTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.verify;
 import hudson.plugins.timestamper.io.TimestampsWriter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -118,6 +119,15 @@ public class TimestamperOutputStreamTest {
   @Test
   public void testWriteIntTwoLines() throws Exception {
     timestamperOutputStream.write('a');
+    timestamperOutputStream.write(NEWLINE);
+    timestamperOutputStream.write('b');
+    verify(writer, times(2)).write(anyLong(), eq(1));
+  }
+
+  @Test
+  public void unicode() throws Exception {
+    String symbol = "Envoi d'une requˆte 'Ping'  127.0.0.1 avec 32 octets de donn‚esÿ:";
+    timestamperOutputStream.write(symbol.getBytes(Charset.forName("Windows-1252")));
     timestamperOutputStream.write(NEWLINE);
     timestamperOutputStream.write('b');
     verify(writer, times(2)).write(anyLong(), eq(1));


### PR DESCRIPTION
This was noticed initially by a customer running Windows agent with the French locale. Timestamps were off. Switching to the english locale was fixing it.

Looking this up, I noticed that some unicode characters contain the byte `FF` (`-1` in decimal), which was used here as a way to detect the beginning of the stream. This was causing the timestamp to apply to 2 lines instead of 1.

This updates the initial value to `Integer.MIN_VALUE` which is guaranteed not to collide with a conversion `byte` -> `int`.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
