### PR TITLE
Specify explicit content type

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
@@ -24,6 +24,9 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+  
+  <st:contentType value="text/html" />
+  
   <j:new var="h" className="hudson.Functions" />
   ${h.initPageVariables(context)}
 


### PR DESCRIPTION
Without specifying the content type you can end-up in your browser displaying garbage.

In our scenario, the data automatically converted by jenkins into gzip encoded content. 
Chrome autofixes this scenario while Firefox just displays the gzip encoded content, which causes the script to die with an javascript error.

Which results in this panel displaying garbage characters like described int JENKINS-64266

Explicitly specifying the content type as html fixes this issue.  Thus this might also fix the issue described in JENKINS-64266.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue