### PR TITLE
Fix wrong offset in large logs when some are skipped.

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParser.java
+++ b/src/main/java/hudson/plugins/timestamper/annotator/ConsoleLogParser.java
@@ -105,7 +105,6 @@ class ConsoleLogParser implements Serializable {
 
   private ConsoleLogParser.Result parseFromFinish(InputStream inputStream) throws IOException {
     ConsoleLogParser.Result result = new ConsoleLogParser.Result();
-    result.lineNumber = -1;
 
     int value = inputStream.read();
     result.atNewLine = isNewLine(value);

--- a/src/test/java/hudson/plugins/timestamper/annotator/ConsoleLogParserTest.java
+++ b/src/test/java/hudson/plugins/timestamper/annotator/ConsoleLogParserTest.java
@@ -150,7 +150,7 @@ public class ConsoleLogParserTest {
   public void testSeekWithinLineNegative_notBuilding() throws Exception {
     assumeThat(isBuilding, is(false));
     ConsoleLogParser.Result result = new ConsoleLogParser.Result();
-    result.lineNumber = -5;
+    result.lineNumber = -4;
     assertThat(seek(1 - logLength), is(result));
   }
 
@@ -167,7 +167,7 @@ public class ConsoleLogParserTest {
   public void testSeekNextLineNegative_notBuilding() throws Exception {
     assumeThat(isBuilding, is(false));
     ConsoleLogParser.Result result = new ConsoleLogParser.Result();
-    result.lineNumber = -4;
+    result.lineNumber = -3;
     result.atNewLine = true;
     assertThat(seek(2 - logLength), is(result));
   }


### PR DESCRIPTION
Timestamps in large logs written to console have wrong
positive offset when logs are partly skipped. So you never
see the last timestamp in the situation.

Changes made in commit 5a5e7b9 touch Parse From Finish logic
and began the offset.
They were partly reverted.