### PR TITLE
fix: return timestamps

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/pipeline/TimestamperStep.java
+++ b/src/main/java/hudson/plugins/timestamper/pipeline/TimestamperStep.java
@@ -109,7 +109,7 @@ public class TimestamperStep extends Step {
         /** {@inheritDoc} */
         @Override
         public String getFunctionName() {
-            return "timestamps";
+            return "timestamps()";
         }
 
         /** {@inheritDoc} */


### PR DESCRIPTION
I found a bug in pipeline-syntax with the plugin "[Pipeline: Declarative](https://plugins.jenkins.io/pipeline-model-definition/)". When I try to generate the pipeline option "Timestamps" the output is:
option
{timespams}
but it should be
option
{timespams()}

### Testing done
Locally

### Change
I changed the return value from the function "getFunctionName".
Here is the new output.
![timestamp](https://github.com/jenkinsci/timestamper-plugin/assets/125879270/c998fdfa-cee6-4383-86cc-c6d226ba1993)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- x[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
