### PR TITLE
Update widget appearance

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/settingsForm.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/settingsForm.jelly
@@ -1,17 +1,29 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-<form>
-    <label>
-        <input type="radio" name="timestamps" id="timestamper-systemTime">${%System clock time}</input>
-    </label>
-    <label>
-        <input type="checkbox" id="timestamper-localTime" style="margin-left: 15px;">${%Use browser timezone}</input>
-    </label>
-    <label>
-        <input type="radio" name="timestamps" id="timestamper-elapsedTime">${%Elapsed time}</input>
-    </label>
-    <label>
-        <input type="radio" name="timestamps" id="timestamper-none">${%None}</input>
-    </label>
-</form>
+    <form>
+        <div class="jenkins-radio">
+            <input type="radio" name="timestamps" id="timestamper-systemTime" class="jenkins-radio__input" />
+            <label for="timestamper-systemTime" class="jenkins-radio__label">
+                ${%System clock time}
+            </label>
+        </div>
+        <div class="jenkins-checkbox jenkins-!-margin-left-2">
+            <input type="checkbox" id="timestamper-localTime" />
+            <label for="timestamper-localTime">
+                ${%Use browser timezone}
+            </label>
+        </div>
+        <div class="jenkins-radio">
+            <input type="radio" name="timestamps" id="timestamper-elapsedTime" class="jenkins-radio__input" />
+            <label for="timestamper-elapsedTime" class="jenkins-radio__label">
+                ${%Elapsed time}
+            </label>
+        </div>
+        <div class="jenkins-radio">
+            <input type="radio" name="timestamps" id="timestamper-none" class="jenkins-radio__input" />
+            <label for="timestamper-none" class="jenkins-radio__label">
+                ${%None}
+            </label>
+        </div>
+    </form>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
@@ -29,23 +29,36 @@ THE SOFTWARE.
   
   <l:ajax>
     <style>
-      .timestamper-form-pane {
-        padding: .5rem 1rem;
-        clear: both
+      #timestamper-pane .pane-header-title {
+        display: flex;
+        justify-content: space-between;
       }
-      .timestamper-form-pane label {
-        line-height: 2rem;
-        display: block;
+      .timestamper-form-pane {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+
+        form {
+          display: contents;
+        }
+
+        * {
+          margin-top: 0 !important;
+          margin-bottom: 0 !important;
+          top: 0 !important;
+        }
       }
     </style>
-    <div>
-      <div class="pane-header col-xs-24">
-        <span class="pane-header-title">${%Timestamps}</span>
-        <span><a class="timestamper-plain-text" href="${it.plainTextUrl}">${%View as plain text}</a></span>
-      </div>
-      <div class="timestamper-form-pane">
+
+    <j:set var="title">
+      <span class="pane-header-title">${%Timestamps}</span>
+      <a class="timestamper-plain-text" href="${it.plainTextUrl}">${%View as plain text}</a>
+    </j:set>
+
+    <l:pane width="3" title="${title}" id="timestamper-pane">
+      <div class="timestamper-form-pane jenkins-!-padding-2">
         <st:include page="settingsForm.jelly"/>
       </div>
-    </div>
+    </l:pane>
   </l:ajax>
 </j:jelly>


### PR DESCRIPTION
Running on the latest Jenkins' `master`, Timestamper's widget no longer uses the Jenkins' widget style. This MR fixes that and updates the style of radios/checkboxes to be inline with Jenkins.

**What's changed**
* Updates the widget to use the `<l:pane/>` component
* Updates the radios/checkboxes to use the new Jenkins classes

**Before**
<img width="353" alt="Screenshot 2023-12-19 at 11 39 41" src="https://github.com/jenkinsci/timestamper-plugin/assets/43062514/e223b32d-949d-4f52-87cb-debd623fffea">

**After**
<img width="351" alt="Screenshot 2023-12-19 at 11 41 11" src="https://github.com/jenkinsci/timestamper-plugin/assets/43062514/53e1951b-3fce-42f2-8f5d-ebfdcfcc42d9">

### Testing done

* Controls work as before

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
