### PR TITLE
[JENKINS-71055] Avoid duplicate widget in the side panel of running Pipeline builds

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/script.js
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/script.js
@@ -141,6 +141,7 @@ function displaySettings() {
         // element not found, so return to avoid an error (JENKINS-23867)
         return;
     }
+
     fetch(rootURL + '/extensionList/hudson.console.ConsoleAnnotatorFactory/hudson.plugins.timestamper.annotator.TimestampAnnotatorFactory3/usersettings', {
         method: 'post',
         headers: crumb.wrap({}),

--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/script.js
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/script.js
@@ -33,7 +33,6 @@ that the changes take effect when upgrading the Timestamper plugin.
 // http://googleblog.blogspot.com.au/2007/07/cookies-expiring-sooner-to-improve.html
 
 var cookieName = 'jenkins-timestamper';
-var timestamperLoaded = false;
 
 function init() {
     // Only one of these modes can be checked at a time.
@@ -138,12 +137,10 @@ function getCookie(suffix) {
 
 function displaySettings() {
     var element = document.getElementById('side-panel');
-    if (null == element || timestamperLoaded) {
-        // side-panel element not found, so return to avoid an error (JENKINS-23867)
-        // when timestamper widget is already loaded
+    if (null == element) {
+        // element not found, so return to avoid an error (JENKINS-23867)
         return;
     }
-    timestamperLoaded = true;
     fetch(rootURL + '/extensionList/hudson.console.ConsoleAnnotatorFactory/hudson.plugins.timestamper.annotator.TimestampAnnotatorFactory3/usersettings', {
         method: 'post',
         headers: crumb.wrap({}),
@@ -163,7 +160,7 @@ function onLoad() {
         return;
     }
     var observer = new MutationObserver(function(mutations) {
-        mutations.forEach(function(mutation) {
+        for (mutation of mutations) {
             var addedNodes = mutation.addedNodes;
             for (var i = 0; i < addedNodes.length; i++) {
                 var node = addedNodes[i];
@@ -174,7 +171,7 @@ function onLoad() {
                     return;
                 }
             }
-        });
+        }
     });
     observer.observe(document, { childList: true, subtree: true });
 }

--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/script.js
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/script.js
@@ -33,6 +33,7 @@ that the changes take effect when upgrading the Timestamper plugin.
 // http://googleblog.blogspot.com.au/2007/07/cookies-expiring-sooner-to-improve.html
 
 var cookieName = 'jenkins-timestamper';
+var timestamperLoaded = false;
 
 function init() {
     // Only one of these modes can be checked at a time.
@@ -137,11 +138,12 @@ function getCookie(suffix) {
 
 function displaySettings() {
     var element = document.getElementById('side-panel');
-    if (null == element) {
-        // element not found, so return to avoid an error (JENKINS-23867)
+    if (null == element || timestamperLoaded) {
+        // side-panel element not found, so return to avoid an error (JENKINS-23867)
+        // when timestamper widget is already loaded
         return;
     }
-
+    timestamperLoaded = true;
     fetch(rootURL + '/extensionList/hudson.console.ConsoleAnnotatorFactory/hudson.plugins.timestamper.annotator.TimestampAnnotatorFactory3/usersettings', {
         method: 'post',
         headers: crumb.wrap({}),


### PR DESCRIPTION
while a pipeline build is running, the timestamper widget is displayed twice. This change avoids this.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
