### PR TITLE
Revert "[JENKINS-72690] Make the widget sticky (#287)"

### DIFF
--- a/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
+++ b/src/main/resources/hudson/plugins/timestamper/annotator/TimestampAnnotatorFactory3/usersettings.jelly
@@ -29,10 +29,6 @@ THE SOFTWARE.
   
   <l:ajax>
     <style>
-      #timestamper-pane {
-        position: sticky;
-        top: 44px;
-      }
       #timestamper-pane .pane-header-title {
         display: flex;
         justify-content: space-between;


### PR DESCRIPTION
When other panels have been added to the side bar, they are shown overlapping with the stick timestamper panel which has a transparent background.  That is noticeable with the Collapsible Section plugin which can generate a fairly long panel. That was reported by @mPokornyETM on https://github.com/jenkinsci/collapsing-console-sections-plugin/pull/35#issuecomment-2442455320:

![image](https://github.com/user-attachments/assets/1f1130d8-1c26-46a2-acbb-c9a9b15c7202)

I understand the use case for making it sticky when the plugin is used by itself, but the overlapping text is concerning.

This reverts commit b2e06b50de137bc74a5016cf49f27686b45a814e.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
