### PR TITLE
fix: [JENKINS-75929] Handle timestamp-only lines to avoid StringIndexOutOfBoundsException

### DIFF
--- a/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
@@ -105,11 +105,11 @@ public class TimestampLogFileLineAccessor implements Closeable {
             if (timestamp != null) {
                 // If we succeeded, then the log file was decorated by GlobalDecorator. Strip the
                 // timestamp decoration from the front of the line.
-                if (logFileLine.length() > 27) {  
+                if (logFileLine.length() > 27) {
                     logFileLine = logFileLine.substring(27);
                 } else {
                     logFileLine = "";
-            }
+                }
             } else {
                 // Attempt to read the timestamp from TimestampNotes embedded in the log file.
                 // Such TimestampNotes are present for Pipeline builds prior to version 1.9 as well

--- a/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
+++ b/src/main/java/hudson/plugins/timestamper/accessor/TimestampLogFileLineAccessor.java
@@ -105,7 +105,11 @@ public class TimestampLogFileLineAccessor implements Closeable {
             if (timestamp != null) {
                 // If we succeeded, then the log file was decorated by GlobalDecorator. Strip the
                 // timestamp decoration from the front of the line.
-                logFileLine = logFileLine.substring(27);
+                if (logFileLine.length() > 27) {  
+                    logFileLine = logFileLine.substring(27);
+                } else {
+                    logFileLine = "";
+            }
             } else {
                 // Attempt to read the timestamp from TimestampNotes embedded in the log file.
                 // Such TimestampNotes are present for Pipeline builds prior to version 1.9 as well

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -164,4 +164,20 @@ class PipelineTest {
                     line);
         }
     }
+
+    @Issue("JENKINS-75929")
+    @Test
+    void timestampOnlyLine() throws Exception {
+        WorkflowJob project = r.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition("echo ''\necho 'Hello'\n", true));
+        WorkflowRun build = r.buildAndAssertSuccess(project);
+        // Ensure no StringIndexOutOfBoundsException is thrown when processing log lines
+        for (String line : build.getLog(Integer.MAX_VALUE)) {
+            if (GlobalAnnotator.parseTimestamp(line, build.getStartTimeInMillis()).isPresent()) {
+                // This must not throw even if line is exactly 27 chars (timestamp only)
+                String content = line.length() > 27 ? line.substring(27) : "";
+                assertNotNull(content);
+            }
+        }
+    }
 }

--- a/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
+++ b/src/test/java/hudson/plugins/timestamper/pipeline/PipelineTest.java
@@ -164,20 +164,4 @@ class PipelineTest {
                     line);
         }
     }
-
-    @Issue("JENKINS-75929")
-    @Test
-    void timestampOnlyLine() throws Exception {
-        WorkflowJob project = r.createProject(WorkflowJob.class);
-        project.setDefinition(new CpsFlowDefinition("echo ''\necho 'Hello'\n", true));
-        WorkflowRun build = r.buildAndAssertSuccess(project);
-        // Ensure no StringIndexOutOfBoundsException is thrown when processing log lines
-        for (String line : build.getLog(Integer.MAX_VALUE)) {
-            if (GlobalAnnotator.parseTimestamp(line, build.getStartTimeInMillis()).isPresent()) {
-                // This must not throw even if line is exactly 27 chars (timestamp only)
-                String content = line.length() > 27 ? line.substring(27) : "";
-                assertNotNull(content);
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Problem
When a Pipeline log line contains only a timestamp prefix with no following 
content, the unconditional `logFileLine.substring(27)` call threw a 
`StringIndexOutOfBoundsException`.

## Root Cause
In `TimestampLogFileLineAccessor.java` line 108, `substring(27)` was called 
without checking if the line was longer than 27 characters.

## Fix
Added a bounds check:
- Lines longer than 27 chars → content extracted as before  
- Lines of exactly 27 chars (timestamp only) → returns empty string

Fixes: JENKINS-75929